### PR TITLE
feat: extract shim implementation into an own module for re-use

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
     - twind - [tw](https://github.com/tw-in-js/twind/tree/main/docs/tw.md) and [setup](https://github.com/tw-in-js/twind/tree/main/docs/setup.md)
     - [twind/colors](https://github.com/tw-in-js/twind/tree/main/docs/setup.md#colors) - the Tailwind v2 [extended color palette](https://tailwindcss.com/docs/customizing-colors#color-palette-reference)
     - [twind/css](https://github.com/tw-in-js/twind/tree/main/docs/css-in-js.md) - how to apply custom css
+    - [twind/observe](https://github.com/tw-in-js/twind/tree/main/docs/observe.md) - the base for [twind/shim](https://github.com/tw-in-js/twind/tree/main/docs/installation.md#twindshim) which can be used standalone
     - [twind/server](https://github.com/tw-in-js/twind/tree/main/docs/ssr.md) - how to extract the generated css on the server
     - [twind/sheets](https://github.com/tw-in-js/twind/tree/main/docs/sheets.md) - several additional sheet implementations that can be used with [setup({ sheet })](https://github.com/tw-in-js/twind/tree/main/docs/setup.md#sheet).
     - [twind/shim](https://github.com/tw-in-js/twind/tree/main/docs/installation.md#twindshim) - allows to copy-paste tailwind examples

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ If you find any incorrect or missing documentation then please [open an issue](h
   - [twind/colors](./setup.md#colors) - the Tailwind v2 [extended color palette](https://tailwindcss.com/docs/customizing-colors#color-palette-reference)
   - [twind/css](./css-in-js.md) - how to apply custom css
   - [twind/server](./ssr.md) - how to extract the generated css on the server
+  - [twind/observe](./observe.md) - the base for [twind/shim](./installation.md#twindshim) which can be used standalone
   - [twind/sheets](./sheets.md) - several additional sheet implementations that can be used with [setup({ sheet })](./setup.md#sheet).
   - [twind/shim](./installation.md#twindshim) - allows to copy-paste tailwind examples
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -68,8 +68,7 @@ Assuming you have an internet connection then you should now be able to use the 
 
 > Allows to copy-paste tailwind examples. This feature can be used together with your favorite framework without any additional setup.
 
-The `twind/shim` modules allows to use the `class` attribute for tailwind rules. If such a rule is detected the corresponding CSS rule is created and injected
-into the stylesheet. _No need for `tw`_ but it can be used on the same page as well (see example below).
+The `twind/shim` modules allows to use the `class` attribute for tailwind rules. If such a rule is detected the corresponding CSS rule is created and injected into the stylesheet. _No need for `tw`_ but it can be used on the same page as well (see example below).
 
 ```html
 <!DOCTYPE html>
@@ -149,8 +148,14 @@ To prevent FOUC (flash of unstyled content) it is advised to set the `hidden` at
 
 <details><summary>How can I use twind/shim from javascript (Click to expand)</summary>
 
+> Internally `twind/shim` uses [twind/observe](./observe.md) which may be useful for advanced use cases.
+
 ```js
 import 'twind/shim'
+```
+
+```js
+import { setup, disconnect } from 'twind/shim'
 ```
 
 </details>
@@ -161,6 +166,7 @@ import 'twind/shim'
 
 ```html
 <script defer src="https://unpkg.com/twind/twind.umd.js"></script>
+<script defer src="https://unpkg.com/twind/observe/observe.umd.js"></script>
 <script defer src="https://unpkg.com/twind/shim/shim.umd.js"></script>
 ```
 
@@ -168,7 +174,7 @@ import 'twind/shim'
 
 <details><summary>Implementation Details (Click to expand)</summary>
 
-This uses a [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) to detect changed class attributes or added DOM nodes. On detection the class attribute is parsed and translated by twind to inject the required classes into the stylesheet and the class attribute is updated to reflect the added CSS class names that may have been hashed.
+`twind/shim` starts [observing](./observe.md) class attributes changes right after the [DOM content has been loaded](https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event). For further details see [twind/observe - Implementation Details](./observe.md#implementation-details).
 
 </details>
 

--- a/docs/observe.md
+++ b/docs/observe.md
@@ -1,0 +1,131 @@
+# twind/observe
+
+> Allows to copy-paste tailwind examples. This feature can be used together with your favorite framework without any additional setup.
+
+The `twind/observe` modules allows to use the `class` attribute for tailwind rules. If such a rule is detected the corresponding CSS rule is created and injected into the stylesheet. _No need for `tw`_ but it can be used on the same elements as well.
+
+> This is meant for advanced use cases. Most of the time you may want to use [twind/shim](./installation.md#twindshim).
+
+<details><summary>Table Of Contents (Click To Expand)</summary>
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Usage](#usage)
+- [Customization](#customization)
+- [API](#api)
+- [Example](#example)
+- [Implementation Details](#implementation-details)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+</details>
+
+## Usage
+
+```js
+import { observe } from 'twind/observe'
+
+observe(document.body)
+
+document.body.innerHTML = `
+  <main class="h-screen bg-purple-400 flex items-center justify-center">
+    <h1 class="font-bold text(center 5xl white sm:gray-800 md:pink-700)">
+      This is Twind!
+    </h1>
+  </main>
+`
+```
+
+> [live and interactive shim demo](https://esm.codes/#aW1wb3J0IHsgb2JzZXJ2ZSB9IGZyb20gJ3R3aW5kL29ic2VydmUnCgpvYnNlcnZlKGRvY3VtZW50LmJvZHkpCgpkb2N1bWVudC5ib2R5LmlubmVySFRNTCA9IGAKICA8bWFpbiBjbGFzcz0iaC1zY3JlZW4gYmctcHVycGxlLTQwMCBmbGV4IGl0ZW1zLWNlbnRlciBqdXN0aWZ5LWNlbnRlciI+CiAgICA8aDEgY2xhc3M9ImZvbnQtYm9sZCB0ZXh0KGNlbnRlciA1eGwgd2hpdGUgc206Z3JheS04MDAgbWQ6cGluay03MDApIj4KICAgICAgVGhpcyBpcyBUd2luZCEKICAgIDwvaDE+CiAgPC9tYWluPgpg)
+
+All twind syntax features like [grouping](./grouping.md) are supported.
+
+> If you want to simplify the instantiation and automatically observe take look at [twind/shim](./installation.md#twindshim).
+
+## Customization
+
+`twind/observe` uses the default/global `tw` instance if not configured otherwise. You can provide a custom instance in several ways:
+
+```js
+import { create } from 'twind'
+import { observe, createObserver } from 'twind/observe'
+
+// Create a custom instance
+const instance = create(/* ... */)
+
+// 1. As second parameter
+observe(document.body, instance)
+
+// 2. As this context
+observe.call(document.body)
+observe.bind(instance)(document.body)
+
+// 3. Use the factory
+createObserver(instance).observe(document.body)
+```
+
+## API
+
+```js
+import { createObserver, observe } from 'twind/observe'
+
+const observer = createObserver(/* custom instance */)
+// Or to start observing an element right away
+// const observer = observe(document.body)
+
+// Start observing a node
+observer.observe(node)
+
+// Stop observing
+observer.disconnect(node)
+```
+
+## Example
+
+> This example show how a custom observer instance can be used to shim a web component.
+
+```js
+import { LitElement, html } from 'lit-element'
+import { create, cssomSheet } from 'twind'
+import { createObserver } from 'twind/observe'
+
+// 1. Create separate CSSStyleSheet
+const sheet = cssomSheet({ target: new CSSStyleSheet() })
+
+// 2. Use that to create an own twind instance
+const instance = create({ sheet })
+
+class TwindElement extends LitElement {
+  // 3. Apply the same style to each instance of this component
+  static styles = [sheet.target]
+
+  // 4. Start observing class attributes changes
+  connectedCallback() {
+    this._observer = createObserver(instance).observe(this.renderRoot)
+  }
+
+  // 5. Stop observing class attributes changes
+  disconnectedCallback() {
+    this._observer.disconnect()
+  }
+
+  render() {
+    // 5. Use tailwind rules in class attributes
+    return html`
+      <main class="h-screen bg-purple-400 flex items-center justify-center">
+        <h1 class="font-bold text(center 5xl white sm:gray-800 md:pink-700)">This is Twind!</h1>
+      </main>
+    `
+  }
+}
+
+customElements.define('twind-element', TwindElement)
+
+document.body.innerHTML = '<twind-element></twind-element>'
+```
+
+> [live and interactive demo](https://esm.codes/#aW1wb3J0IHsgTGl0RWxlbWVudCwgaHRtbCB9IGZyb20gJ2h0dHBzOi8vY2RuLnNreXBhY2suZGV2L2xpdC1lbGVtZW50JwppbXBvcnQgeyBjcmVhdGUsIGNzc29tU2hlZXQgfSBmcm9tICdodHRwczovL2Nkbi5za3lwYWNrLmRldi90d2luZCcKaW1wb3J0IHsgY3JlYXRlT2JzZXJ2ZXIgfSBmcm9tICdodHRwczovL2Nkbi5za3lwYWNrLmRldi90d2luZC9vYnNlcnZlJwoKY29uc3Qgc2hlZXQgPSBjc3NvbVNoZWV0KHsgdGFyZ2V0OiBuZXcgQ1NTU3R5bGVTaGVldCgpIH0pCgpjb25zdCB7IHR3IH0gPSBjcmVhdGUoeyBzaGVldCB9KQoKY2xhc3MgVHdpbmRFbGVtZW50IGV4dGVuZHMgTGl0RWxlbWVudCB7CiAgY3JlYXRlUmVuZGVyUm9vdCgpIHsKICAgIGNvbnN0IHNoYWRvdyA9IHN1cGVyLmNyZWF0ZVJlbmRlclJvb3QoKQogICAgc2hhZG93LmFkb3B0ZWRTdHlsZVNoZWV0cyA9IFtzaGVldC50YXJnZXRdCiAgICByZXR1cm4gc2hhZG93CiAgfQoKICBjb25uZWN0ZWRDYWxsYmFjaygpIHsKICAgIHRoaXMuX29ic2VydmVyID0gY3JlYXRlT2JzZXJ2ZXIoaW5zdGFuY2UpLm9ic2VydmUodGhpcy5yZW5kZXJSb290KQogIH0KCiAgZGlzY29ubmVjdGVkQ2FsbGJhY2soKSB7CiAgICB0aGlzLl9vYnNlcnZlci5kaXNjb25uZWN0KCkKICB9CgogIHJlbmRlcigpIHsKICAgIHJldHVybiBodG1sYAogICAgICA8bWFpbiBjbGFzcz0iaC1zY3JlZW4gYmctcHVycGxlLTQwMCBmbGV4IGl0ZW1zLWNlbnRlciBqdXN0aWZ5LWNlbnRlciI+CiAgICAgICAgPGgxIGNsYXNzPSJmb250LWJvbGQgdGV4dChjZW50ZXIgNXhsIHdoaXRlIHNtOmdyYXktODAwIG1kOnBpbmstNzAwKSI+CiAgICAgICAgICBUaGlzIGlzIFR3aW5kIQogICAgICAgIDwvaDE+CiAgICAgIDwvbWFpbj4KICAgIGAKICB9Cn0KCmN1c3RvbUVsZW1lbnRzLmRlZmluZSgndHdpbmQtZWxlbWVudCcsIFR3aW5kRWxlbWVudCk7Cgpkb2N1bWVudC5ib2R5LmlubmVySFRNTCA9ICc8dHdpbmQtZWxlbWVudD48L3R3aW5kLWVsZW1lbnQ+Jwo=)
+
+## Implementation Details
+
+This uses a [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) to detect changed class attributes or added DOM nodes. On detection the class attribute is parsed and translated by twind to inject the required classes into the stylesheet and the class attribute is updated to reflect the added CSS class names that may have been hashed.

--- a/docs/observe.md
+++ b/docs/observe.md
@@ -57,7 +57,7 @@ const instance = create(/* ... */)
 observe(document.body, instance)
 
 // 2. As this context
-observe.call(document.body)
+observe.call(instance, document.body)
 observe.bind(instance)(document.body)
 
 // 3. Use the factory
@@ -70,14 +70,15 @@ createObserver(instance).observe(document.body)
 import { createObserver, observe } from 'twind/observe'
 
 const observer = createObserver(/* custom instance */)
-// Or to start observing an element right away
-// const observer = observe(document.body)
 
-// Start observing a node
+// Or to start observing an element right away
+// const observer = observe(node, /* custom instance */)
+
+// Start observing a node; can be called several times with different nodes
 observer.observe(node)
 
-// Stop observing
-observer.disconnect(node)
+// Stop observing all nodes
+observer.disconnect()
 ```
 
 ## Example

--- a/docs/observe.md
+++ b/docs/observe.md
@@ -82,7 +82,9 @@ observer.disconnect(node)
 
 ## Example
 
-> This example show how a custom observer instance can be used to shim a web component.
+This example shows how a custom observer instance can be used to shim a web component.
+
+> This example is using [Constructable Stylesheet Objects](https://wicg.github.io/construct-stylesheets/) and `DocumentOrShadowRoot.adoptedStyleSheets` which have [limited browser support](https://caniuse.com/mdn-api_documentorshadowroot_adoptedstylesheets) at the moment (December 2020).
 
 ```js
 import { LitElement, html } from 'lit-element'
@@ -101,11 +103,13 @@ class TwindElement extends LitElement {
 
   // 4. Start observing class attributes changes
   connectedCallback() {
+    super.connectedCallback()
     this._observer = createObserver(instance).observe(this.renderRoot)
   }
 
   // 5. Stop observing class attributes changes
   disconnectedCallback() {
+    super.disconnectedCallback()
     this._observer.disconnect()
   }
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     ".": "./src/index.ts",
     "./colors": "./src/colors/index.ts",
     "./css": "./src/css/index.ts",
+    "./observe": "./src/observe/index.ts",
     "./shim": "./src/shim/index.ts",
     "./server": "./src/server/index.ts",
     "./sheets": "./src/sheets/index.ts",

--- a/src/observe/index.ts
+++ b/src/observe/index.ts
@@ -1,0 +1,116 @@
+import type { TW } from '../types'
+import { tw as defaultTW } from '../index'
+
+export interface ShimConfiguration {
+  tw?: TW
+}
+
+/** Provides the ability to watch for changes being made to the DOM tree. */
+export interface TwindObserver {
+  /**
+   * Stops observer from observing any mutations.
+   */
+  disconnect(): TwindObserver
+
+  /**
+   * Observe an additional element.
+   */
+  observe(target: Node): TwindObserver
+}
+
+const caches = new WeakMap<TW, Map<string, string>>()
+
+const getCache = (tw: TW): Map<string, string> => {
+  let rulesToClassCache = caches.get(tw)
+
+  if (!rulesToClassCache) {
+    rulesToClassCache = new Map<string, string>()
+    caches.set(tw, rulesToClassCache)
+  }
+
+  return rulesToClassCache
+}
+
+export const createObserver = ({ tw = defaultTW }: ShimConfiguration = {}): TwindObserver => {
+  const rulesToClassCache = getCache(tw)
+
+  const handleMutation = ({ target, addedNodes }: MutationRecord): void => {
+    // Not using target.classList.value (not supported in all browsers) or target.class (this is an SVGAnimatedString for svg)
+    const rules = (target as Element).getAttribute?.('class')
+
+    if (rules) {
+      let className = rulesToClassCache.get(rules)
+
+      if (!className) {
+        className = tw(rules)
+
+        // Remember the generated class name
+        rulesToClassCache.set(rules, className)
+
+        // Ensure the cache does not grow unlimited
+        if (rulesToClassCache.size > 10000) {
+          rulesToClassCache.delete(rulesToClassCache.keys().next().value)
+        }
+      }
+
+      if (rules !== className) {
+        // Not using `target.className = ...` as that is read-only for SVGElements
+        // eslint-disable-next-line @typescript-eslint/no-extra-semi
+        ;(target as Element).setAttribute('class', className)
+      }
+    }
+
+    for (let index = addedNodes.length; index--; ) {
+      const node = addedNodes[index]
+
+      handleMutations([
+        {
+          target: node,
+          addedNodes: (node as Element).children || [],
+        },
+      ])
+    }
+  }
+
+  const handleMutations = (mutations: MutationRecord[]): void => mutations.forEach(handleMutation)
+
+  const observer = new MutationObserver(handleMutations)
+
+  return {
+    observe(target) {
+      handleMutations([{ target, addedNodes: [target] }])
+
+      observer.observe(target, {
+        attributes: true,
+        attributeFilter: ['class'],
+        subtree: true,
+        childList: true,
+      })
+
+      return this
+    },
+
+    disconnect() {
+      observer.disconnect()
+      return this
+    },
+  }
+}
+export function observe(
+  this: ShimConfiguration | undefined | void,
+  target: Node,
+  config: ShimConfiguration | undefined | void = this,
+): TwindObserver {
+  return createObserver(config as ShimConfiguration | undefined).observe(target)
+}
+
+interface NodeList {
+  readonly length: number
+
+  [index: number]: Node
+}
+
+interface MutationRecord {
+  readonly addedNodes: NodeList
+  readonly target: Node
+}

--- a/src/observe/index.ts
+++ b/src/observe/index.ts
@@ -34,7 +34,7 @@ const getCache = (tw: TW): Map<string, string> => {
 export const createObserver = ({ tw = defaultTW }: ShimConfiguration = {}): TwindObserver => {
   const rulesToClassCache = getCache(tw)
 
-  const handleMutation = ({ target, addedNodes }: MutationRecord): void => {
+  const handleMutation = ({ target, addedNodes }: MinimalMutationRecord): void => {
     // Not using target.classList.value (not supported in all browsers) or target.class (this is an SVGAnimatedString for svg)
     const rules = (target as Element).getAttribute?.('class')
 
@@ -72,7 +72,8 @@ export const createObserver = ({ tw = defaultTW }: ShimConfiguration = {}): Twin
     }
   }
 
-  const handleMutations = (mutations: MutationRecord[]): void => mutations.forEach(handleMutation)
+  const handleMutations = (mutations: MinimalMutationRecord[]): void =>
+    mutations.forEach(handleMutation)
 
   const observer = new MutationObserver(handleMutations)
 
@@ -104,13 +105,12 @@ export function observe(
   return createObserver(config as ShimConfiguration | undefined).observe(target)
 }
 
-interface NodeList {
-  readonly length: number
-
-  [index: number]: Node
-}
-
-interface MutationRecord {
-  readonly addedNodes: NodeList
+/**
+ * Simplified MutationRecord which allows use to pass an
+ * ArrayLike (compatible with Array and NodeList) `addedNodes` and
+ * omit other properties we are not interested in.
+ */
+interface MinimalMutationRecord {
+  readonly addedNodes: ArrayLike<Node>
   readonly target: Node
 }

--- a/src/shim/index.ts
+++ b/src/shim/index.ts
@@ -1,66 +1,12 @@
 import type { Configuration } from '../types'
-import { tw, setup as setupTW } from '../index'
+import type { TwindObserver } from '../observe'
+
+import { setup as setupTW } from '../index'
+import { createObserver } from '../observe/index'
 
 export interface ShimConfiguration extends Configuration {
   target?: HTMLElement
 }
-
-interface NodeList {
-  readonly length: number
-
-  [index: number]: Node
-}
-
-interface MutationRecord {
-  readonly addedNodes: NodeList
-  readonly target: Node
-}
-
-const rulesToClassCache = new Map<string, string>()
-
-const handleMutation = ({ target, addedNodes }: MutationRecord): void => {
-  // Not using target.classList.value (not supported in all browsers) or target.class (this is an SVGAnimatedString for svg)
-  const rules = (target as Element).getAttribute?.('class')
-
-  if (rules) {
-    let className = rulesToClassCache.get(rules)
-
-    if (!className) {
-      className = tw(rules)
-
-      // Remember the generated class name
-      rulesToClassCache.set(rules, className)
-
-      // Ensure the cache does not grow unlimited
-      if (rulesToClassCache.size > 10000) {
-        rulesToClassCache.delete(rulesToClassCache.keys().next().value)
-      }
-    }
-
-    if (rules !== className) {
-      // Not using `target.className = ...` as that is read-only for SVGElements
-      // eslint-disable-next-line @typescript-eslint/no-extra-semi
-      ;(target as Element).setAttribute('class', className)
-    }
-  }
-
-  for (let index = addedNodes.length; index--; ) {
-    const node = addedNodes[index]
-
-    handleMutations([
-      {
-        target: node,
-        addedNodes: (node as Element).children || [],
-      },
-    ])
-  }
-}
-
-const handleMutations = (mutations: MutationRecord[]): void => mutations.forEach(handleMutation)
-
-const observer = new MutationObserver(handleMutations)
-
-export const stop = (): void => observer.disconnect()
 
 const onload = () => {
   const script = document.querySelector('script[type="twind-config"]')
@@ -78,29 +24,29 @@ if (document.readyState === 'loading') {
   var timeoutRef = setTimeout(onload)
 }
 
+const observer = createObserver()
+
+export const disconnect = (): void => {
+  // Removing the callbacks ensures that the setup is called only once
+  // either programmatically from userland or by DOMContentLoaded/setTimeout
+  removeEventListener('DOMContentLoaded', onload)
+  clearTimeout(timeoutRef)
+
+  observer.disconnect()
+}
+
 export const setup = ({
   target = document.documentElement,
   ...config
 }: ShimConfiguration = {}): void => {
-  // Removing the callbacks ensures that the setup is called only once
-  // either by programmatically from userland or by DOMContentLoaded/timeout
-  removeEventListener('DOMContentLoaded', onload)
-  clearTimeout(timeoutRef)
-
   if (Object.keys(config).length) {
     setupTW(config)
   }
 
-  stop()
+  // Remove event listeners
+  disconnect()
 
-  handleMutations([{ target, addedNodes: [target] }])
+  observer.observe(target)
 
   target.hidden = false
-
-  observer.observe(target, {
-    attributes: true,
-    attributeFilter: ['class'],
-    subtree: true,
-    childList: true,
-  })
 }


### PR DESCRIPTION
This PR allows to use several shim instance (observer) on a page. This may be useful for advanced use cases like web components (#15).

See https://github.com/tw-in-js/twind/blob/twind-observe/docs/observe.md for details.

The basic idea is the following:

```js
import { observe } from 'twind/observe'

observe(document.body)

document.body.innerHTML = `
  <main class="h-screen bg-purple-400 flex items-center justify-center">
    <h1 class="font-bold text(center 5xl white sm:gray-800 md:pink-700)">
      This is Twind!
    </h1>
  </main>
`
```

