### PR TITLE
Fix pseudo-element examples

### DIFF
--- a/docs/css-in-js.md
+++ b/docs/css-in-js.md
@@ -21,10 +21,12 @@ Essentially a CSS directive uses some CSS rules in object notation format to cre
 ```js
 import { css } from 'twind/css'
 
-tw(css({
-  '&::before': { content: '🙁' }
-  '&::after': { content: '😊' }
-}))
+tw(
+  css({
+    '&::before': { content: '"🙁"' },
+    '&::after': { content: '"😊"' },
+  }),
+)
 // => tw-xxxx
 ```
 
@@ -32,8 +34,8 @@ For best performance it is advised to extract CSS directive into a variable:
 
 ```js
 const styles = css({
-  '&::before': { content: '🙁' }
-  '&::after': { content: '😊' }
+  '&::before': { content: '"🙁"' },
+  '&::after': { content: '"😊"' },
 })
 
 tw(styles)
@@ -45,8 +47,8 @@ Furthermore any variants or groupings that are active when the CSS directive is 
 ```js
 tw`
   sm:hover:${css({
-    '&::before': { content: '🙁' }
-    '&::after': { content: '😊' }
+    '&::before': { content: '"🙁"' },
+    '&::after': { content: '"😊"' },
   })}
 `
 // => sm:hover:tw-xxxx
@@ -69,8 +71,8 @@ CSS directives can be used without applying it through `tw`:
 
 ```js
 document.body.className = css({
-  '&::before': { content: '🙁' }
-  '&::after': { content: '😊' }
+  '&::before': { content: '"🙁"' },
+  '&::after': { content: '"😊"' },
 })
 // => tw-xxxx
 ```
@@ -84,20 +86,20 @@ const { tw } = create(/* options */)
 const cx = css.bind(tw)
 
 document.body.className = cx({
-  '&::before': { content: '🙁' }
-  '&::after': { content: '😊' }
+  '&::before': { content: '"🙁"' },
+  '&::after': { content: '"😊"' },
 })
 
 // Or providing tw on invocation
 document.body.className = css.call(tw, {
-  '&::before': { content: '🙁' }
-  '&::after': { content: '😊' }
+  '&::before': { content: '"🙁"' },
+  '&::after': { content: '"😊"' },
 })
 
 // Or providing tw on generation
 const smiley = css({
-  '&::before': { content: '🙁' }
-  '&::after': { content: '😊' }
+  '&::before': { content: '"🙁"' },
+  '&::after': { content: '"😊"' },
 })
 document.body.className = smiley({ tw })
 ```

--- a/docs/grouping.md
+++ b/docs/grouping.md
@@ -105,7 +105,7 @@ It is possible to define arbitrary styles by providing a function. Like all othe
 
 ```js
 tw`
-  hover:${css({ '&::after': { content: '🌈' } })}
+  hover:${css({ '&::after': { content: '"🌈"' } })}
 
   hover:${({ tw }) => ({
     sm: tw`underline`,

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -132,8 +132,8 @@ If you find yourself in this circumstance, use an inline plugin:
 
 ```js
 tw(({ theme }) => ({
-  '&::before': { content: '🙁' }
-  '&::after': { content: '😊' }
+  '&::before': { content: '"🙁"' },
+  '&::after': { content: '"😊"' },
 }))
 // => tw-xxxx
 ```
@@ -145,8 +145,8 @@ Furthermore any variants or groupings that are active when the plugin is called,
 ```js
 tw`
   sm:hover:${() => ({
-    '&::before': { content: '🙁' }
-    '&::after': { content: '😊' }
+    '&::before': { content: '"🙁"' },
+    '&::after': { content: '"😊"' },
   })}
 `
 // => sm:hover:tw-xxxx
@@ -159,8 +159,8 @@ In the above example, the before and after styles are only applied on small scre
 > ```js
 > tw`
 >   sm:hover:${css({
->     '&::before': { content: '🙁' }
->     '&::after': { content: '😊' }
+>     '&::before': { content: '"🙁"' },
+>     '&::after': { content: '"😊"' },
 >   })}
 > `
 > // => sm:hover:tw-xxxx

--- a/docs/tw.md
+++ b/docs/tw.md
@@ -132,7 +132,7 @@ Sometimes developers might want to break out of the defined Tailwind grammar and
 ```js
 tw`
   text-sm
-  ${() => ({ '&::after': { content: '🌈' } })}
+  ${() => ({ '&::after': { content: '"🌈"' } })}
 `
 ```
 


### PR DESCRIPTION
CSS-in-JS string values need to be quoted to produce valid CSS.

Resolves #21.