### PR TITLE
refactor: remove support for non-tw usage

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -133,17 +133,7 @@ tw`${btnLarge} rounded-md`
 // .rounded-md { ... }
 ```
 
-The returned function has `toString` and `valueOf` methods which inject the styles and return the class name without the need to pass theme to `tw`:
-
-```jsx
-;<button className={apply`bg-red bg-blue`}>blue</button>
-// => tw-red-blue
-
-document.body.className = apply`bg-blue bg-red`
-// => tw-blue-red
-```
-
-Or use this helper:
+You can use this helper to use `apply` together with `tw`:
 
 ```jsx
 import { tw, apply } from 'twind'

--- a/docs/css-in-js.md
+++ b/docs/css-in-js.md
@@ -246,27 +246,18 @@ const bounce = animation(
 )
 ```
 
-The second parameter are the waypoints of a [@keyframes](https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes) at-rule in CSS object format.
+The second parameter are the waypoints of a [@keyframes](https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes) at-rule in CSS object format. The [keyframes helper](#keyframes-helper) can be used the create waypoints.
 
-Just like CSS Directives they can be used without a `tw` function:
-
-```js
-document.body.className = bounce
-```
-
-To use a custom `tw` function you can bind the `animate` function just like you can with CSS directives.
+The result of `animation` can be used within `css`:
 
 ```js
-import { create } from 'twind'
-
-const { tw } = create(/* options */)
-
-const animate = animation.bind(tw)
-
-// Or providing tw on invocation
-const bounce = animation.call(tw, {
-  /* same as above */
+css(bounce, {
+  /* other properties */
 })
+
+css`
+  ${bounce}
+`
 ```
 
 ## Keyframes Helper

--- a/docs/css-in-js.md
+++ b/docs/css-in-js.md
@@ -148,36 +148,6 @@ css`
 `
 ```
 
-CSS directives can be used without applying it through `tw`:
-
-```js
-document.body.className = css({
-  '&::before': { content: '"🙁"' },
-  '&::after': { content: '"😊"' },
-})
-// => tw-xxxx
-```
-
-This works because they have a `toString()` function that internally calls default `tw` to generate a class name. To use a custom `tw` function you can bind the `css` function:
-
-```js
-import { create } from 'twind'
-
-const { tw } = create(/* options */)
-const cx = css.bind(tw)
-
-document.body.className = cx({
-  '&::before': { content: '"🙁"' },
-  '&::after': { content: '"😊"' },
-})
-
-// Or providing tw on invocation
-document.body.className = css.call(tw, {
-  '&::before': { content: '"🙁"' },
-  '&::after': { content: '"😊"' },
-})
-```
-
 ### Accessing the theme
 
 Values of the CSS object maybe functions that are passed the context and should return the value to be used:
@@ -351,27 +321,6 @@ animation('1s ease infinite', bounce)
 css({
   animation: '1s ease infinite',
   animationName: bounce,
-})
-```
-
-Keyframes can be used without another `css` or `animation`:
-
-```js
-document.body.style.animation = `${bounce} 1s ease infinite`
-```
-
-This works because they have a `toString()` function that internally calls the default `tw` to generate a class name. To use a custom `tw` function you can bind the `keyframes` function:
-
-```js
-import { create } from 'twind'
-
-const { tw } = create(/* options */)
-
-const kf = keyframes.bind(tw)
-
-// Or providing tw on invocation
-const bounce = keyframes.call(tw, {
-  /* same as above */
 })
 ```
 

--- a/src/__tests__/apply.test.ts
+++ b/src/__tests__/apply.test.ts
@@ -62,20 +62,6 @@ test('child components', ({ tw, sheet }) => {
   ])
 })
 
-test('non tw usage (toString)', ({ tw, sheet }) => {
-  const btn = apply.call(tw, `inline-block`)
-
-  assert.is(btn.toString(), 'tw-ri1alh')
-  assert.equal(sheet.target, ['.tw-ri1alh{display:inline-block}'])
-})
-
-test('non tw usage (valueOf)', ({ tw, sheet }) => {
-  const btn = apply.call(tw, `inline-block`)
-
-  assert.is(btn.valueOf(), 'tw-ri1alh')
-  assert.equal(sheet.target, ['.tw-ri1alh{display:inline-block}'])
-})
-
 test('with variants', ({ tw, sheet }) => {
   const btn = apply`
     py-2 px-4

--- a/src/css/README.md
+++ b/src/css/README.md
@@ -149,36 +149,6 @@ css`
 `
 ```
 
-CSS directives can be used without applying it through `tw`:
-
-```js
-document.body.className = css({
-  '&::before': { content: '"🙁"' },
-  '&::after': { content: '"😊"' },
-})
-// => tw-xxxx
-```
-
-This works because they have a `toString()` function that internally calls default `tw` to generate a class name. To use a custom `tw` function you can bind the `css` function:
-
-```js
-import { create } from 'twind'
-
-const { tw } = create(/* options */)
-const cx = css.bind(tw)
-
-document.body.className = cx({
-  '&::before': { content: '"🙁"' },
-  '&::after': { content: '"😊"' },
-})
-
-// Or providing tw on invocation
-document.body.className = css.call(tw, {
-  '&::before': { content: '"🙁"' },
-  '&::after': { content: '"😊"' },
-})
-```
-
 ### Accessing the theme
 
 Values of the CSS object maybe functions that are passed the context and should return the value to be used:
@@ -281,27 +251,6 @@ const bounce = animation(
 
 The second parameter are the waypoints of a [@keyframes](https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes) at-rule in CSS object format.
 
-Just like CSS Directives they can be used without a `tw` function:
-
-```js
-document.body = bounce
-```
-
-To use a custom `tw` function you can bind the `animate` function just like you can with CSS directives.
-
-```js
-import { create } from 'twind'
-
-const { tw } = create(/* options */)
-
-const animate = animation.bind(tw)
-
-// Or providing tw on invocation
-const bounce = animation.call(tw, {
-  /* same as above */
-})
-```
-
 ## Keyframes Helper
 
 The {@link keyframes} export helps to create custom [@keyframes](https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes):
@@ -354,26 +303,5 @@ animation('1s ease infinite', bounce)
 css({
   animation: '1s ease infinite',
   animationName: bounce,
-})
-```
-
-Keyframes can be used without another `css` or `animation`:
-
-```js
-document.body.style.animation = `${bounce} 1s ease infinite`
-```
-
-This works because they have a `toString()` function that internally calls the default `tw` to generate a class name. To use a custom `tw` function you can bind the `keyframes` function:
-
-```js
-import { create } from 'twind'
-
-const { tw } = create(/* options */)
-
-const kf = keyframes.bind(tw)
-
-// Or providing tw on invocation
-const bounce = keyframes.call(tw, {
-  /* same as above */
 })
 ```

--- a/src/css/css.test.ts
+++ b/src/css/css.test.ts
@@ -110,42 +110,6 @@ test('can be used with variants', ({ tw, sheet }) => {
   ])
 })
 
-test('toString uses bound tw', ({ css, sheet }) => {
-  const style = css({
-    color: 'rebeccapurple',
-  })
-
-  assert.is(`${style}`, 'tw-1ha8m0q')
-  assert.equal(sheet.target, ['.tw-1ha8m0q{color:rebeccapurple}'])
-})
-
-test('valueOf uses bound tw', ({ css, sheet }) => {
-  const style = css({
-    color: 'hotpink',
-  })
-
-  assert.is(style.valueOf(), 'tw-14q97zu')
-  assert.equal(sheet.target, ['.tw-14q97zu{color:hotpink}'])
-})
-
-test('toString uses global tw', ({ sheet }) => {
-  const style = css({
-    color: 'rebeccapurple',
-  })
-
-  assert.is(`${style}`, 'tw-1ha8m0q')
-  assert.equal(sheet.target, [])
-})
-
-test('valueOf uses global tw', ({ sheet }) => {
-  const style = css({
-    color: 'hotpink',
-  })
-
-  assert.is(style.valueOf(), 'tw-14q97zu')
-  assert.equal(sheet.target, [])
-})
-
 test('keyframes', ({ keyframes, css, tw, sheet }) => {
   const bounce = keyframes({
     'from, 20%, 53%, 80%, to': {
@@ -168,14 +132,14 @@ test('keyframes', ({ keyframes, css, tw, sheet }) => {
   assert.is(
     tw(
       css({
-        animation: `${bounce} 1s ease infinite`,
+        animation: animation(`1s ease infinite`, bounce),
       }),
     ),
-    'tw-1v80189',
+    'tw-4l4ydd',
   )
   assert.equal(sheet.target, [
+    '.tw-4l4ydd animation{animation:1s ease infinite;animation-name:tw-cm8eaz}',
     '@keyframes tw-cm8eaz{from, 20%, 53%, 80%, to{transform:translate3d(0,0,0)}40%, 43%{transform:translate3d(0, -30px, 0)}70%{transform:translate3d(0, -15px, 0)}90%{transform:translate3d(0, -4px, 0)}}',
-    '.tw-1v80189{animation:tw-cm8eaz 1s ease infinite}',
   ])
 })
 

--- a/src/twind/apply.ts
+++ b/src/twind/apply.ts
@@ -11,8 +11,8 @@ export function apply(
   ...interpolations: Token[]
 ): ApplyDirective
 
-export function apply(this: TW | null | undefined | void, ...tokens: Token[]): ApplyDirective
+export function apply(...tokens: Token[]): ApplyDirective
 
-export function apply(this: TW | null | undefined | void, ...tokens: unknown[]): ApplyDirective {
-  return directive(applyFactory, tokens, this)
+export function apply(...tokens: unknown[]): ApplyDirective {
+  return directive(applyFactory, tokens)
 }

--- a/src/twind/plugins.ts
+++ b/src/twind/plugins.ts
@@ -45,8 +45,8 @@ const themeProperty = (section?: keyof Theme): DirectiveHandler => (
   [section || id]: theme(section || (id as keyof Theme), params) as string,
 })
 
-const alias = (directive: DirectiveHandler, name: string): DirectiveHandler => (params, context) =>
-  directive(params, context, name)
+const alias = (handler: DirectiveHandler, name: string): DirectiveHandler => (params, context) =>
+  handler(params, context, name)
 
 const display = property('display')
 const position = property('position')


### PR DESCRIPTION
Currently `apply`, `css`, `keyframes` and `animation` support non-tw usage:

```js
document.body.className = apply`bg-gray-50 text-gray-800`

const bounce = keyframes`...`
document.body.style.animation = `${bounce} 1s ease infinite`
```

This works as the returned function have `toString` and `valueOf` method which use the bound `tw` to generate the styles. Using a custom `tw` instance is supported by:

```js
const { tw } = create(/* options */)

const kf = keyframes.bind(tw)

// Or providing tw on invocation
const bounce = keyframes.call(tw, {
  /* same as above */
})
```

This feature is quite difficult to understand for beginners and maybe confusing when stumbled on it in the docs. By removing it we can enforce that only explicit `tw` calls generate and inject styles. **No magic**!

I would like to drop this in favor of requiring the explicit use of `tw` or using a helper:

```js
document.body.className = tw(apply`bg-gray-50 text-gray-800`)

// Using a helper
const twind = (...args) => tw(apply(...args))

document.body.className = twind`bg-blue bg-red`
```

I think that most use cases can be achieved now using a combination of `tw` with `apply`, `css`, `keyframes` and `animation`.

Would do you think? @tw-in-js/contributors 