### PR TITLE
feat: arrays and objects with raw, min or max properties for screen

### DIFF
--- a/src/__tests__/api.json
+++ b/src/__tests__/api.json
@@ -454,6 +454,9 @@
       ".animate-spin{animation:spin 1s linear infinite}"
     ]
   ],
+  "print:text-black": "@media print{.print\\:text-black{--tw-text-opacity:1;color:#000;color:rgba(0,0,0,var(--tw-text-opacity))}}",
+  "portrait:text-black": "@media (orientation: portrait){.portrait\\:text-black{--tw-text-opacity:1;color:#000;color:rgba(0,0,0,var(--tw-text-opacity))}}",
+  "standalone:text-black": "@media (display-mode:standalone){.standalone\\:text-black{--tw-text-opacity:1;color:#000;color:rgba(0,0,0,var(--tw-text-opacity))}}",
   "(text(center 2xl) underline)": [
     "text-center text-2xl underline",
     [
@@ -611,7 +614,7 @@
       ".divide-y-2>:not([hidden])~:not([hidden]){--tw-divide-y-reverse:0;border-bottom-width:calc(2px * var(--tw-divide-y-reverse));border-top-width:2px;border-top-width:calc(2px * calc(1 - var(--tw-divide-y-reverse)))}",
       ".divide-green-600>:not([hidden])~:not([hidden]){--tw-divide-opacity:1;border-color:#059669;border-color:rgba(5,150,105,var(--tw-divide-opacity))}",
       ".divide-opacity-80>:not([hidden])~:not([hidden]){--tw-divide-opacity:0.8}",
-      "@media (min-width: 768px){.md\\:divide-opacity-50>:not([hidden])~:not([hidden]){--tw-divide-opacity:0.5}}"
+      "@media (min-width:768px){.md\\:divide-opacity-50>:not([hidden])~:not([hidden]){--tw-divide-opacity:0.5}}"
     ]
   ],
   "active:hover:text-lg hover:text(center active:(underline) purple-500) hover:active:ring(& opacity-5) font(bold)": [
@@ -696,48 +699,48 @@
     [
       ".-rotate-3{--tw-rotate:calc(3deg * -1);transform:rotate(calc(3deg * -1));transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}",
       ".hover\\:rotate-6:hover{--tw-rotate:6deg;transform:rotate(6deg);transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}",
-      "@media (min-width: 768px){.md\\:rotate-3{--tw-rotate:3deg;transform:rotate(3deg);transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}}",
-      "@media (min-width: 768px){.md\\:hover\\:-rotate-6:hover{--tw-rotate:calc(6deg * -1);transform:rotate(calc(6deg * -1));transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}}"
+      "@media (min-width:768px){.md\\:rotate-3{--tw-rotate:3deg;transform:rotate(3deg);transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}}",
+      "@media (min-width:768px){.md\\:hover\\:-rotate-6:hover{--tw-rotate:calc(6deg * -1);transform:rotate(calc(6deg * -1));transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}}"
     ]
   ],
   "container": [
     "container",
     [
       ".container{width:100%}",
-      "@media (min-width: 640px){.container{max-width:640px}}",
-      "@media (min-width: 768px){.container{max-width:768px}}",
-      "@media (min-width: 1024px){.container{max-width:1024px}}",
-      "@media (min-width: 1280px){.container{max-width:1280px}}",
-      "@media (min-width: 1536px){.container{max-width:1536px}}"
+      "@media (min-width:640px){.container{max-width:640px}}",
+      "@media (min-width:768px){.container{max-width:768px}}",
+      "@media (min-width:1024px){.container{max-width:1024px}}",
+      "@media (min-width:1280px){.container{max-width:1280px}}",
+      "@media (min-width:1536px){.container{max-width:1536px}}"
     ]
   ],
   "container md:max-w-md": [
     "container md:max-w-md",
     [
       ".container{width:100%}",
-      "@media (min-width: 640px){.container{max-width:640px}}",
-      "@media (min-width: 768px){.container{max-width:768px}}",
-      "@media (min-width: 1024px){.container{max-width:1024px}}",
-      "@media (min-width: 1280px){.container{max-width:1280px}}",
-      "@media (min-width: 1536px){.container{max-width:1536px}}",
-      "@media (min-width: 768px){.md\\:max-w-md{max-width:28rem}}"
+      "@media (min-width:640px){.container{max-width:640px}}",
+      "@media (min-width:768px){.container{max-width:768px}}",
+      "@media (min-width:1024px){.container{max-width:1024px}}",
+      "@media (min-width:1280px){.container{max-width:1280px}}",
+      "@media (min-width:1536px){.container{max-width:1536px}}",
+      "@media (min-width:768px){.md\\:max-w-md{max-width:28rem}}"
     ]
   ],
   "md:(container mx-auto)": [
     "md:container md:mx-auto",
     [
-      "@media (min-width: 768px){.md\\:mx-auto{margin-left:auto;margin-right:auto}}",
-      "@media (min-width: 768px){.md\\:container{width:100%}}",
-      "@media (min-width: 768px){@media (min-width: 640px){.md\\:container{max-width:640px}}}",
-      "@media (min-width: 768px){@media (min-width: 768px){.md\\:container{max-width:768px}}}",
-      "@media (min-width: 768px){@media (min-width: 1024px){.md\\:container{max-width:1024px}}}",
-      "@media (min-width: 768px){@media (min-width: 1280px){.md\\:container{max-width:1280px}}}",
-      "@media (min-width: 768px){@media (min-width: 1536px){.md\\:container{max-width:1536px}}}"
+      "@media (min-width:768px){.md\\:mx-auto{margin-left:auto;margin-right:auto}}",
+      "@media (min-width:768px){.md\\:container{width:100%}}",
+      "@media (min-width:768px){@media (min-width:640px){.md\\:container{max-width:640px}}}",
+      "@media (min-width:768px){@media (min-width:768px){.md\\:container{max-width:768px}}}",
+      "@media (min-width:768px){@media (min-width:1024px){.md\\:container{max-width:1024px}}}",
+      "@media (min-width:768px){@media (min-width:1280px){.md\\:container{max-width:1280px}}}",
+      "@media (min-width:768px){@media (min-width:1536px){.md\\:container{max-width:1536px}}}"
     ]
   ],
   "hover:md:text-center": [
     "hover:md:text-center",
-    ["@media (min-width: 768px){.hover\\:md\\:text-center:hover{text-align:center}}"]
+    ["@media (min-width:768px){.hover\\:md\\:text-center:hover{text-align:center}}"]
   ],
   "ordinal slashed-zero tabular-nums md:normal-nums": [
     "ordinal slashed-zero tabular-nums md:normal-nums",
@@ -745,7 +748,7 @@
       ".ordinal{--tw-ordinal:ordinal;font-variant-numeric:var(--tw-ordinal,/*!*/ /*!*/) var(--tw-slashed-zero,/*!*/ /*!*/) var(--tw-numeric-figure,/*!*/ /*!*/) var(--tw-numeric-spacing,/*!*/ /*!*/) var(--tw-numeric-fraction,/*!*/ /*!*/)}",
       ".slashed-zero{--tw-slashed-zero:slashed-zero;font-variant-numeric:var(--tw-ordinal,/*!*/ /*!*/) var(--tw-slashed-zero,/*!*/ /*!*/) var(--tw-numeric-figure,/*!*/ /*!*/) var(--tw-numeric-spacing,/*!*/ /*!*/) var(--tw-numeric-fraction,/*!*/ /*!*/)}",
       ".tabular-nums{--tw-numeric-spacing:tabular-nums;font-variant-numeric:var(--tw-ordinal,/*!*/ /*!*/) var(--tw-slashed-zero,/*!*/ /*!*/) var(--tw-numeric-figure,/*!*/ /*!*/) var(--tw-numeric-spacing,/*!*/ /*!*/) var(--tw-numeric-fraction,/*!*/ /*!*/)}",
-      "@media (min-width: 768px){.md\\:normal-nums{font-variant-numeric:normal}}"
+      "@media (min-width:768px){.md\\:normal-nums{font-variant-numeric:normal}}"
     ]
   ],
   "lining-nums": ".lining-nums{--tw-numeric-figure:lining-nums;font-variant-numeric:var(--tw-ordinal,/*!*/ /*!*/) var(--tw-slashed-zero,/*!*/ /*!*/) var(--tw-numeric-figure,/*!*/ /*!*/) var(--tw-numeric-spacing,/*!*/ /*!*/) var(--tw-numeric-fraction,/*!*/ /*!*/)}",

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -24,6 +24,18 @@ test.before((context) => {
     prefix: false,
     theme: {
       extend: {
+        screens: {
+          standalone: { raw: '(display-mode:standalone)' },
+          portrait: { raw: '(orientation: portrait)' },
+          print: { raw: 'print' },
+          special: [
+            // Sidebar appears at 768px, so revert to `sm:` styles between 768px
+            // and 868px, after which the main content area is wide enough again to
+            // apply the `md:` styles.
+            { min: '668px', max: '767px' },
+            { min: '868px' },
+          ],
+        },
         colors: { fuchsia: 'fuchsia' },
         backgroundImage: {
           'hero-pattern': "url('/img/hero-pattern.svg')",
@@ -128,11 +140,11 @@ test('responsive presedence', ({ sheet, tw }) => {
   assert.is(tw`m(lg:9 2xl:6 xl:5 md:9 sm:7 8)`, 'lg:m-9 2xl:m-6 xl:m-5 md:m-9 sm:m-7 m-8')
   assert.equal(sheet.target, [
     '.m-8{margin:2rem}',
-    '@media (min-width: 640px){.sm\\:m-7{margin:1.75rem}}',
-    '@media (min-width: 768px){.md\\:m-9{margin:2.25rem}}',
-    '@media (min-width: 1024px){.lg\\:m-9{margin:2.25rem}}',
-    '@media (min-width: 1280px){.xl\\:m-5{margin:1.25rem}}',
-    '@media (min-width: 1536px){.\\32 xl\\:m-6{margin:1.5rem}}',
+    '@media (min-width:640px){.sm\\:m-7{margin:1.75rem}}',
+    '@media (min-width:768px){.md\\:m-9{margin:2.25rem}}',
+    '@media (min-width:1024px){.lg\\:m-9{margin:2.25rem}}',
+    '@media (min-width:1280px){.xl\\:m-5{margin:1.25rem}}',
+    '@media (min-width:1536px){.\\32 xl\\:m-6{margin:1.5rem}}',
   ])
 })
 
@@ -146,10 +158,10 @@ test('at-rules presedence', ({ sheet, tw }) => {
     '@media (prefers-reduced-motion:reduce){.motion-reduce\\:m-5{margin:1.25rem}}',
     '@supports ((position: -webkit-sticky) or (position:sticky)){.sticky\\:m-6{margin:1.5rem}}',
     '@media (prefers-reduced-motion:no-preference){.motion-safe\\:m-9{margin:2.25rem}}',
-    '@media (min-width: 1024px){.lg\\:m-9{margin:2.25rem}}',
-    '@media (min-width: 1024px){@media (prefers-reduced-motion:no-preference){.lg\\:motion-safe\\:m-12{margin:3rem}}}',
+    '@media (min-width:1024px){.lg\\:m-9{margin:2.25rem}}',
+    '@media (min-width:1024px){@media (prefers-reduced-motion:no-preference){.lg\\:motion-safe\\:m-12{margin:3rem}}}',
     '@media (prefers-color-scheme:dark){.dark\\:m-7{margin:1.75rem}}',
-    '@media (min-width: 768px){@media (prefers-color-scheme:dark){.md\\:dark\\:m-4{margin:1rem}}}',
+    '@media (min-width:768px){@media (prefers-color-scheme:dark){.md\\:dark\\:m-4{margin:1rem}}}',
   ])
 })
 
@@ -281,15 +293,15 @@ test('properties presedence (divide)', ({ sheet, tw }) => {
     'sm:hover:rounded sm:active:rounded-full md:rounded md:hover:bg-white lg:rounded-full lg:hover:bg-white lg:hover:text-black lg:hover:active:underline lg:hover:active:shadow',
     [
       '*{--tw-shadow:0 0 transparent}',
-      '@media (min-width: 640px){.sm\\:hover\\:rounded:hover{border-radius:0.25rem}}',
-      '@media (min-width: 640px){.sm\\:active\\:rounded-full:active{border-radius:9999px}}',
-      '@media (min-width: 768px){.md\\:rounded{border-radius:0.25rem}}',
-      '@media (min-width: 768px){.md\\:hover\\:bg-white:hover{--tw-bg-opacity:1;background-color:#fff;background-color:rgba(255,255,255,var(--tw-bg-opacity))}}',
-      '@media (min-width: 1024px){.lg\\:rounded-full{border-radius:9999px}}',
-      '@media (min-width: 1024px){.lg\\:hover\\:text-black:hover{--tw-text-opacity:1;color:#000;color:rgba(0,0,0,var(--tw-text-opacity))}}',
-      '@media (min-width: 1024px){.lg\\:hover\\:bg-white:hover{--tw-bg-opacity:1;background-color:#fff;background-color:rgba(255,255,255,var(--tw-bg-opacity))}}',
-      '@media (min-width: 1024px){.lg\\:hover\\:active\\:shadow:hover:active{--tw-shadow:0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);box-shadow:0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);box-shadow:var(--tw-ring-offset-shadow,0 0 transparent),var(--tw-ring-shadow,0 0 transparent),var(--tw-shadow)}}',
-      '@media (min-width: 1024px){.lg\\:hover\\:active\\:underline:hover:active{text-decoration:underline}}',
+      '@media (min-width:640px){.sm\\:hover\\:rounded:hover{border-radius:0.25rem}}',
+      '@media (min-width:640px){.sm\\:active\\:rounded-full:active{border-radius:9999px}}',
+      '@media (min-width:768px){.md\\:rounded{border-radius:0.25rem}}',
+      '@media (min-width:768px){.md\\:hover\\:bg-white:hover{--tw-bg-opacity:1;background-color:#fff;background-color:rgba(255,255,255,var(--tw-bg-opacity))}}',
+      '@media (min-width:1024px){.lg\\:rounded-full{border-radius:9999px}}',
+      '@media (min-width:1024px){.lg\\:hover\\:text-black:hover{--tw-text-opacity:1;color:#000;color:rgba(0,0,0,var(--tw-text-opacity))}}',
+      '@media (min-width:1024px){.lg\\:hover\\:bg-white:hover{--tw-bg-opacity:1;background-color:#fff;background-color:rgba(255,255,255,var(--tw-bg-opacity))}}',
+      '@media (min-width:1024px){.lg\\:hover\\:active\\:shadow:hover:active{--tw-shadow:0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);box-shadow:0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);box-shadow:var(--tw-ring-offset-shadow,0 0 transparent),var(--tw-ring-shadow,0 0 transparent),var(--tw-shadow)}}',
+      '@media (min-width:1024px){.lg\\:hover\\:active\\:underline:hover:active{text-decoration:underline}}',
     ],
   ],
 ].forEach(([tokens, classNames, rules]) => {
@@ -360,10 +372,10 @@ test('tw`bg-white sm:${["rounded"]} text-black hover:${{sm: ({tw}) => tw`underli
     '.text-black{--tw-text-opacity:1;color:#000;color:rgba(0,0,0,var(--tw-text-opacity))}',
     '.bg-white{--tw-bg-opacity:1;background-color:#fff;background-color:rgba(255,255,255,var(--tw-bg-opacity))}',
     '.font-bold{font-weight:700}',
-    '@media (min-width: 640px){.sm\\:rounded{border-radius:0.25rem}}',
-    '@media (min-width: 640px){.hover\\:sm\\:underline:hover{text-decoration:underline}}',
-    '@media (min-width: 1024px){.hover\\:lg\\:no-underline:hover{text-decoration:none}}',
-    '@media (min-width: 1024px){.hover\\:lg\\:line-through:hover{text-decoration:line-through}}',
+    '@media (min-width:640px){.sm\\:rounded{border-radius:0.25rem}}',
+    '@media (min-width:640px){.hover\\:sm\\:underline:hover{text-decoration:underline}}',
+    '@media (min-width:1024px){.hover\\:lg\\:no-underline:hover{text-decoration:none}}',
+    '@media (min-width:1024px){.hover\\:lg\\:line-through:hover{text-decoration:line-through}}',
   ])
 })
 
@@ -394,7 +406,7 @@ test('tw`bg-${"fuchsia"}) sm:${"underline"} lg:${false && "line-through"} text-$
     '.text-underline{text-decoration:underline}',
     '.text-center{text-align:center}',
     '.rounded-xl{border-radius:0.75rem}',
-    '@media (min-width: 640px){.sm\\:underline{text-decoration:underline}}',
+    '@media (min-width:640px){.sm\\:underline{text-decoration:underline}}',
   ])
 })
 
@@ -474,11 +486,11 @@ test('container center', ({ sheet }) => {
   assert.is(tw`container`, 'container')
   assert.equal(sheet.target, [
     '.container{width:100%;margin-right:auto;margin-left:auto}',
-    '@media (min-width: 640px){.container{max-width:640px}}',
-    '@media (min-width: 768px){.container{max-width:768px}}',
-    '@media (min-width: 1024px){.container{max-width:1024px}}',
-    '@media (min-width: 1280px){.container{max-width:1280px}}',
-    '@media (min-width: 1536px){.container{max-width:1536px}}',
+    '@media (min-width:640px){.container{max-width:640px}}',
+    '@media (min-width:768px){.container{max-width:768px}}',
+    '@media (min-width:1024px){.container{max-width:1024px}}',
+    '@media (min-width:1280px){.container{max-width:1280px}}',
+    '@media (min-width:1536px){.container{max-width:1536px}}',
   ])
 })
 
@@ -500,11 +512,11 @@ test('container padding', ({ sheet }) => {
   assert.is(tw`container`, 'container')
   assert.equal(sheet.target, [
     '.container{width:100%;padding-right:2rem;padding-left:2rem}',
-    '@media (min-width: 640px){.container{max-width:640px;padding-right:2rem;padding-left:2rem}}',
-    '@media (min-width: 768px){.container{max-width:768px;padding-right:2rem;padding-left:2rem}}',
-    '@media (min-width: 1024px){.container{max-width:1024px;padding-right:2rem;padding-left:2rem}}',
-    '@media (min-width: 1280px){.container{max-width:1280px;padding-right:2rem;padding-left:2rem}}',
-    '@media (min-width: 1536px){.container{max-width:1536px;padding-right:2rem;padding-left:2rem}}',
+    '@media (min-width:640px){.container{max-width:640px;padding-right:2rem;padding-left:2rem}}',
+    '@media (min-width:768px){.container{max-width:768px;padding-right:2rem;padding-left:2rem}}',
+    '@media (min-width:1024px){.container{max-width:1024px;padding-right:2rem;padding-left:2rem}}',
+    '@media (min-width:1280px){.container{max-width:1280px;padding-right:2rem;padding-left:2rem}}',
+    '@media (min-width:1536px){.container{max-width:1536px;padding-right:2rem;padding-left:2rem}}',
   ])
 })
 
@@ -532,11 +544,11 @@ test('container padding per screeen', ({ sheet }) => {
   assert.is(tw`container`, 'container')
   assert.equal(sheet.target, [
     '.container{width:100%;padding-right:1rem;padding-left:1rem}',
-    '@media (min-width: 640px){.container{max-width:640px;padding-right:2rem;padding-left:2rem}}',
-    '@media (min-width: 768px){.container{max-width:768px;padding-right:1rem;padding-left:1rem}}',
-    '@media (min-width: 1024px){.container{max-width:1024px;padding-right:4rem;padding-left:4rem}}',
-    '@media (min-width: 1280px){.container{max-width:1280px;padding-right:5rem;padding-left:5rem}}',
-    '@media (min-width: 1536px){.container{max-width:1536px;padding-right:6rem;padding-left:6rem}}',
+    '@media (min-width:640px){.container{max-width:640px;padding-right:2rem;padding-left:2rem}}',
+    '@media (min-width:768px){.container{max-width:768px;padding-right:1rem;padding-left:1rem}}',
+    '@media (min-width:1024px){.container{max-width:1024px;padding-right:4rem;padding-left:4rem}}',
+    '@media (min-width:1280px){.container{max-width:1280px;padding-right:5rem;padding-left:5rem}}',
+    '@media (min-width:1536px){.container{max-width:1536px;padding-right:6rem;padding-left:6rem}}',
   ])
 })
 
@@ -560,11 +572,11 @@ test('responsive if theme screens uses non px values', ({ sheet }) => {
   assert.is(tw`m(xl:8 2xl:16 sm:2 md:3 lg:4 1)`, 'xl:m-8 2xl:m-16 sm:m-2 md:m-3 lg:m-4 m-1')
   assert.equal(sheet.target, [
     '.m-1{margin:0.25rem}',
-    '@media (min-width: 40rem){.sm\\:m-2{margin:0.5rem}}',
-    '@media (min-width: 48rem){.md\\:m-3{margin:0.75rem}}',
-    '@media (min-width: 64rem){.lg\\:m-4{margin:1rem}}',
-    '@media (min-width: 80rem){.xl\\:m-8{margin:2rem}}',
-    '@media (min-width: 96rem){.\\32 xl\\:m-16{margin:4rem}}',
+    '@media (min-width:40rem){.sm\\:m-2{margin:0.5rem}}',
+    '@media (min-width:48rem){.md\\:m-3{margin:0.75rem}}',
+    '@media (min-width:64rem){.lg\\:m-4{margin:1rem}}',
+    '@media (min-width:80rem){.xl\\:m-8{margin:2rem}}',
+    '@media (min-width:96rem){.\\32 xl\\:m-16{margin:4rem}}',
   ])
 })
 
@@ -635,7 +647,7 @@ test('inline rule (variants)', ({ sheet, tw }) => {
   assert.equal(sheet.target, [
     '.text-center{text-align:center}',
     '.active\\:font-bold:active{font-weight:700}',
-    '@media (min-width: 640px){.sm\\:hover\\:underline:hover{text-decoration:underline}}',
+    '@media (min-width:640px){.sm\\:hover\\:underline:hover{text-decoration:underline}}',
   ])
 })
 
@@ -660,10 +672,10 @@ test('inline rule nested', ({ sheet, tw }) => {
   assert.equal(sheet.target, [
     '.text-center{text-align:center}',
     '.font-bold{font-weight:700}',
-    '@media (min-width: 640px){.sm\\:hover\\:underline:hover{text-decoration:underline}}',
-    '@media (min-width: 1024px){.lg\\:text-lg{font-size:1.125rem;line-height:1.75rem}}',
-    '@media (min-width: 1024px){.lg\\:focus\\:underline:focus{text-decoration:underline}}',
-    '@media (min-width: 640px){.sm\\:focus\\:tw-lbtuhn:focus{color:#ef4444}}',
+    '@media (min-width:640px){.sm\\:hover\\:underline:hover{text-decoration:underline}}',
+    '@media (min-width:1024px){.lg\\:text-lg{font-size:1.125rem;line-height:1.75rem}}',
+    '@media (min-width:1024px){.lg\\:focus\\:underline:focus{text-decoration:underline}}',
+    '@media (min-width:640px){.sm\\:focus\\:tw-lbtuhn:focus{color:#ef4444}}',
   ])
 })
 

--- a/src/__tests__/apply.test.ts
+++ b/src/__tests__/apply.test.ts
@@ -245,25 +245,25 @@ test('complex', ({ tw, sheet }) => {
     return tw(instanceStyles, className)
   }
 
-  assert.is(Button(), 'tw-10l2puq')
+  assert.is(Button(), 'tw-quup5s')
   assert.equal(sheet.target, [
-    '.tw-10l2puq{width:100%;font-size:0.875rem;line-height:1.25rem;--tw-dxr4o8:1;color:#fff;color:rgba(255,255,255,var(--tw-dxr4o8));text-transform:uppercase;padding-left:0.5rem;padding-right:0.5rem;border-style:none;transition-property:background-color,border-color,color,fill,stroke;transition-timing-function:cubic-bezier(0.4,0,0.2,1);transition-duration:300ms;--tw-17cwy6m:1;background-color:#2563eb;background-color:rgba(37,99,235,var(--tw-17cwy6m));padding-bottom:0.75rem;padding-top:0.75rem;border-radius:0.5rem}',
-    '.tw-10l2puq:hover{--tw-17cwy6m:1;background-color:#1d4ed8;background-color:rgba(29,78,216,var(--tw-17cwy6m))}',
-    '.tw-10l2puq:focus{--tw-17cwy6m:1;background-color:#1d4ed8;background-color:rgba(29,78,216,var(--tw-17cwy6m))}',
-    '@media (min-width: 768px){.tw-10l2puq{width:auto;padding-bottom:0.5rem;padding-top:0.5rem}}',
+    '.tw-quup5s{width:100%;font-size:0.875rem;line-height:1.25rem;--tw-dxr4o8:1;color:#fff;color:rgba(255,255,255,var(--tw-dxr4o8));text-transform:uppercase;padding-left:0.5rem;padding-right:0.5rem;border-style:none;transition-property:background-color,border-color,color,fill,stroke;transition-timing-function:cubic-bezier(0.4,0,0.2,1);transition-duration:300ms;--tw-17cwy6m:1;background-color:#2563eb;background-color:rgba(37,99,235,var(--tw-17cwy6m));padding-bottom:0.75rem;padding-top:0.75rem;border-radius:0.5rem}',
+    '.tw-quup5s:hover{--tw-17cwy6m:1;background-color:#1d4ed8;background-color:rgba(29,78,216,var(--tw-17cwy6m))}',
+    '.tw-quup5s:focus{--tw-17cwy6m:1;background-color:#1d4ed8;background-color:rgba(29,78,216,var(--tw-17cwy6m))}',
+    '@media (min-width:768px){.tw-quup5s{width:auto;padding-bottom:0.5rem;padding-top:0.5rem}}',
   ])
 
   sheet.reset()
 
   assert.is(
     Button({ size: 'sm', round: true, disabled: true, className: 'font-bold' }),
-    'tw-rcqzz4 tw-b13grf',
+    'tw-1ibx07s tw-b13grf',
   )
   assert.equal(sheet.target, [
-    '.tw-rcqzz4{width:100%;font-size:0.75rem;line-height:1rem;--tw-dxr4o8:1;color:#f3f4f6;color:rgba(243,244,246,var(--tw-dxr4o8));text-transform:uppercase;padding-left:0.5rem;padding-right:0.5rem;border-style:none;transition-property:background-color,border-color,color,fill,stroke;transition-timing-function:cubic-bezier(0.4,0,0.2,1);transition-duration:300ms;--tw-17cwy6m:1;background-color:#9ca3af;background-color:rgba(156,163,175,var(--tw-17cwy6m));padding-bottom:0.5rem;padding-top:0.5rem;border-radius:9999px;cursor:not-allowed}',
-    '.tw-rcqzz4:hover{--tw-17cwy6m:1;background-color:#1d4ed8;background-color:rgba(29,78,216,var(--tw-17cwy6m))}',
-    '.tw-rcqzz4:focus{--tw-17cwy6m:1;background-color:#1d4ed8;background-color:rgba(29,78,216,var(--tw-17cwy6m))}',
-    '@media (min-width: 768px){.tw-rcqzz4{width:auto;padding-bottom:0.25rem;padding-top:0.25rem}}',
+    '.tw-1ibx07s{width:100%;font-size:0.75rem;line-height:1rem;--tw-dxr4o8:1;color:#f3f4f6;color:rgba(243,244,246,var(--tw-dxr4o8));text-transform:uppercase;padding-left:0.5rem;padding-right:0.5rem;border-style:none;transition-property:background-color,border-color,color,fill,stroke;transition-timing-function:cubic-bezier(0.4,0,0.2,1);transition-duration:300ms;--tw-17cwy6m:1;background-color:#9ca3af;background-color:rgba(156,163,175,var(--tw-17cwy6m));padding-bottom:0.5rem;padding-top:0.5rem;border-radius:9999px;cursor:not-allowed}',
+    '.tw-1ibx07s:hover{--tw-17cwy6m:1;background-color:#1d4ed8;background-color:rgba(29,78,216,var(--tw-17cwy6m))}',
+    '.tw-1ibx07s:focus{--tw-17cwy6m:1;background-color:#1d4ed8;background-color:rgba(29,78,216,var(--tw-17cwy6m))}',
+    '@media (min-width:768px){.tw-1ibx07s{width:auto;padding-bottom:0.25rem;padding-top:0.25rem}}',
     '.tw-b13grf{font-weight:700}',
   ])
 })

--- a/src/__tests__/dark-mode.test.ts
+++ b/src/__tests__/dark-mode.test.ts
@@ -59,9 +59,9 @@ test('stacking with screens', ({ instance, sheet }) => {
   )
   assert.equal(sheet.target, [
     '.text-\\#111{--tw-text-opacity:1;color:#111;color:rgba(17,17,17,var(--tw-text-opacity))}',
-    '@media (min-width: 1024px){.lg\\:text-black{--tw-text-opacity:1;color:#000;color:rgba(0,0,0,var(--tw-text-opacity))}}',
+    '@media (min-width:1024px){.lg\\:text-black{--tw-text-opacity:1;color:#000;color:rgba(0,0,0,var(--tw-text-opacity))}}',
     '@media (prefers-color-scheme:dark){.dark\\:text-\\#222{--tw-text-opacity:1;color:#222;color:rgba(34,34,34,var(--tw-text-opacity))}}',
-    '@media (min-width: 1024px){@media (prefers-color-scheme:dark){.lg\\:dark\\:text-white{--tw-text-opacity:1;color:#fff;color:rgba(255,255,255,var(--tw-text-opacity))}}}',
+    '@media (min-width:1024px){@media (prefers-color-scheme:dark){.lg\\:dark\\:text-white{--tw-text-opacity:1;color:#fff;color:rgba(255,255,255,var(--tw-text-opacity))}}}',
   ])
 })
 
@@ -73,8 +73,8 @@ test('stacking with other variants', ({ instance, sheet }) => {
   assert.equal(sheet.target, [
     '.text-\\#111{--tw-text-opacity:1;color:#111;color:rgba(17,17,17,var(--tw-text-opacity))}',
     '.hover\\:text-\\#222:hover{--tw-text-opacity:1;color:#222;color:rgba(34,34,34,var(--tw-text-opacity))}',
-    '@media (min-width: 1024px){@media (prefers-color-scheme:dark){.lg\\:dark\\:text-black{--tw-text-opacity:1;color:#000;color:rgba(0,0,0,var(--tw-text-opacity))}}}',
-    '@media (min-width: 1024px){@media (prefers-color-scheme:dark){.lg\\:dark\\:hover\\:text-white:hover{--tw-text-opacity:1;color:#fff;color:rgba(255,255,255,var(--tw-text-opacity))}}}',
+    '@media (min-width:1024px){@media (prefers-color-scheme:dark){.lg\\:dark\\:text-black{--tw-text-opacity:1;color:#000;color:rgba(0,0,0,var(--tw-text-opacity))}}}',
+    '@media (min-width:1024px){@media (prefers-color-scheme:dark){.lg\\:dark\\:hover\\:text-white:hover{--tw-text-opacity:1;color:#fff;color:rgba(255,255,255,var(--tw-text-opacity))}}}',
   ])
 })
 

--- a/src/__tests__/dom.test.ts
+++ b/src/__tests__/dom.test.ts
@@ -28,7 +28,7 @@ test('injects in to a style sheet element', () => {
     [
       '.flex {display: flex;}',
       '.text-center {text-align: center;}',
-      '@media (min-width: 768px) {.md\\:text-left {text-align: left;}}',
+      '@media (min-width:768px) {.md\\:text-left {text-align: left;}}',
     ],
   )
 
@@ -44,10 +44,10 @@ test('injects in to a style sheet element', () => {
     [
       '.flex {display: flex;}',
       '.text-center {text-align: center;}',
-      '@media (min-width: 768px) {.md\\:text-left {text-align: left;}}',
+      '@media (min-width:768px) {.md\\:text-left {text-align: left;}}',
       '.flex {display: flex;}',
       '.text-center {text-align: center;}',
-      '@media (min-width: 768px) {.md\\:text-left {text-align: left;}}',
+      '@media (min-width:768px) {.md\\:text-left {text-align: left;}}',
     ],
   )
 })

--- a/src/__tests__/hash.test.ts
+++ b/src/__tests__/hash.test.ts
@@ -98,10 +98,10 @@ test('bg-gradient-to-r from-purple-500', ({ instance, sheet }) => {
 })
 
 test('different variant produce different hashes', ({ instance, sheet }) => {
-  assert.is(instance.tw('sm:text-center lg:text-center'), 'tw-zqeog8 tw-ymouy7')
+  assert.is(instance.tw('sm:text-center lg:text-center'), 'tw-172fxgp tw-1kpr4zu')
   assert.equal(sheet.target, [
-    '@media (min-width: 640px){.tw-zqeog8{text-align:center}}',
-    '@media (min-width: 1024px){.tw-ymouy7{text-align:center}}',
+    '@media (min-width:640px){.tw-172fxgp{text-align:center}}',
+    '@media (min-width:1024px){.tw-1kpr4zu{text-align:center}}',
   ])
 })
 

--- a/src/__tests__/plugins.test.ts
+++ b/src/__tests__/plugins.test.ts
@@ -38,7 +38,7 @@ test('value can be a token string', ({ setup, sheet }) => {
     '.overflow-hidden{overflow:hidden}',
     '.max-w-md{max-width:28rem}',
     '.rounded-xl{border-radius:0.75rem}',
-    '@media (min-width: 768px){.md\\:max-w-2xl{max-width:42rem}}',
+    '@media (min-width:768px){.md\\:max-w-2xl{max-width:42rem}}',
   ])
 })
 

--- a/src/css/css.test.ts
+++ b/src/css/css.test.ts
@@ -98,8 +98,8 @@ test('can be used with variants', ({ tw, sheet }) => {
   assert.equal(sheet.target, [
     '.focus\\:tw-af5k28:focus:hover{color:darkgreen}',
     '.focus\\:tw-af5k28:focus{background-color:hotpink}',
-    '@media (min-width: 640px){.sm\\:tw-af5k28:hover{color:darkgreen}}',
-    '@media (min-width: 640px){.sm\\:tw-af5k28{background-color:hotpink}}',
+    '@media (min-width:640px){.sm\\:tw-af5k28:hover{color:darkgreen}}',
+    '@media (min-width:640px){.sm\\:tw-af5k28{background-color:hotpink}}',
   ])
 })
 

--- a/src/css/index.ts
+++ b/src/css/index.ts
@@ -5,7 +5,15 @@
  * @module twind/css
  */
 
-import type { CSSRules, CSSAtKeyframes, Context, CSSProperties, Falsy, MaybeThunk } from '../types'
+import type {
+  CSSRules,
+  CSSAtKeyframes,
+  Context,
+  CSSProperties,
+  Falsy,
+  MaybeThunk,
+  MaybeArray,
+} from '../types'
 
 import { hash, directive } from '../index'
 import * as is from '../internal/is'
@@ -16,8 +24,6 @@ export { tw, apply, setup, theme } from '../index'
 export interface CSSDirective {
   (context: Context): CSSRules
 }
-
-export type MaybeArray<T> = T | readonly T[]
 
 export interface CSSFactory<T, I, R> {
   (

--- a/src/internal/util.ts
+++ b/src/internal/util.ts
@@ -1,4 +1,12 @@
-import type { Context, Hasher, Falsy, MaybeThunk, CSSRules } from '../types'
+import type {
+  Context,
+  Hasher,
+  Falsy,
+  MaybeThunk,
+  CSSRules,
+  ThemeScreen,
+  ThemeScreenValue,
+} from '../types'
 
 interface Includes {
   (value: string, search: string): boolean
@@ -79,6 +87,34 @@ export const escape =
     // Simplifed escape testing only for chars that we know happen to be in tailwind directives
     return firstChar + className.replace(/[!./:#]/g, '\\$&')
   })
+
+export const buildMediaQuery = (screen: ThemeScreen): string => {
+  if (!Array.isArray(screen)) {
+    screen = [screen as ThemeScreenValue]
+  }
+
+  return (
+    '@media ' +
+    join(
+      (screen as ThemeScreenValue[]).map((screen) => {
+        if (is.string(screen)) {
+          screen = { min: screen }
+        }
+
+        return (
+          (screen as { raw?: string }).raw ||
+          join(
+            Object.keys(screen).map(
+              (feature) => `(${feature}-width:${(screen as Record<string, string>)[feature]})`,
+            ),
+            ' and ',
+          )
+        )
+      }),
+      ',',
+    )
+  )
+}
 
 // Based on https://stackoverflow.com/a/52171480
 export const cyrb32: Hasher = (value: string): string => {

--- a/src/sheets/dom.test.ts
+++ b/src/sheets/dom.test.ts
@@ -29,7 +29,7 @@ test('injects in to a style sheet element', () => {
     [
       '.flex{display:flex}',
       '.text-center{text-align:center}',
-      '@media (min-width: 768px){.md\\:text-left{text-align:left}}',
+      '@media (min-width:768px){.md\\:text-left{text-align:left}}',
     ].join(''),
   )
 
@@ -45,7 +45,7 @@ test('injects in to a style sheet element', () => {
     [
       '.flex{display:flex}',
       '.text-center{text-align:center}',
-      '@media (min-width: 768px){.md\\:text-left{text-align:left}}',
+      '@media (min-width:768px){.md\\:text-left{text-align:left}}',
       '.font-bold{font-weight:700}',
     ].join(''),
   )

--- a/src/shim/server/shim.test.ts
+++ b/src/shim/server/shim.test.ts
@@ -83,8 +83,8 @@ test('expand class names with preflight', () => {
     '.justify-center{justify-content:center}',
     '.text-center{text-align:center}',
     '.font-bold{font-weight:700}',
-    '@media (min-width: 640px){.sm\\:text-gray-800{--tw-text-opacity:1;color:#1f2937;color:rgba(31,41,55,var(--tw-text-opacity))}}',
-    '@media (min-width: 768px){.md\\:text-pink-700{--tw-text-opacity:1;color:#be185d;color:rgba(190,24,93,var(--tw-text-opacity))}}',
+    '@media (min-width:640px){.sm\\:text-gray-800{--tw-text-opacity:1;color:#1f2937;color:rgba(31,41,55,var(--tw-text-opacity))}}',
+    '@media (min-width:768px){.md\\:text-pink-700{--tw-text-opacity:1;color:#be185d;color:rgba(190,24,93,var(--tw-text-opacity))}}',
   ])
 })
 
@@ -113,7 +113,7 @@ test('hash class names', () => {
     html,
     `
     <main class="tw-s71qpw tw-15v4579 tw-1sv1rgs tw-6q7m7e tw-1u5qtu">
-      <h1 class="tw-5693iz tw-1eqnqhy tw-1ehy2ck tw-f8j2my tw-oxtcu9">
+      <h1 class="tw-5693iz tw-1eqnqhy tw-1ehy2ck tw-1v0lbgq tw-16puy3r">
         This is <span class="tw-b13grf">Twind</span>!
       </h1>
     </main>
@@ -129,8 +129,8 @@ test('hash class names', () => {
     '.tw-1u5qtu{justify-content:center}',
     '.tw-5693iz{text-align:center}',
     '.tw-b13grf{font-weight:700}',
-    '@media (min-width: 640px){.tw-f8j2my{--tw-dxr4o8:1;color:#1f2937;color:rgba(31,41,55,var(--tw-dxr4o8))}}',
-    '@media (min-width: 768px){.tw-oxtcu9{--tw-dxr4o8:1;color:#be185d;color:rgba(190,24,93,var(--tw-dxr4o8))}}',
+    '@media (min-width:640px){.tw-1v0lbgq{--tw-dxr4o8:1;color:#1f2937;color:rgba(31,41,55,var(--tw-dxr4o8))}}',
+    '@media (min-width:768px){.tw-16puy3r{--tw-dxr4o8:1;color:#be185d;color:rgba(190,24,93,var(--tw-dxr4o8))}}',
   ])
 })
 
@@ -179,8 +179,8 @@ test('apply HTML parser options (comment: true)', () => {
     '.justify-center{justify-content:center}',
     '.text-center{text-align:center}',
     '.font-bold{font-weight:700}',
-    '@media (min-width: 640px){.sm\\:text-gray-800{--tw-text-opacity:1;color:#1f2937;color:rgba(31,41,55,var(--tw-text-opacity))}}',
-    '@media (min-width: 768px){.md\\:text-pink-700{--tw-text-opacity:1;color:#be185d;color:rgba(190,24,93,var(--tw-text-opacity))}}',
+    '@media (min-width:640px){.sm\\:text-gray-800{--tw-text-opacity:1;color:#1f2937;color:rgba(31,41,55,var(--tw-text-opacity))}}',
+    '@media (min-width:768px){.md\\:text-pink-700{--tw-text-opacity:1;color:#be185d;color:rgba(190,24,93,var(--tw-text-opacity))}}',
   ])
 })
 
@@ -227,8 +227,8 @@ test('apply HTML parser options with only TW instance', () => {
     '.justify-center{justify-content:center}',
     '.text-center{text-align:center}',
     '.font-bold{font-weight:700}',
-    '@media (min-width: 640px){.sm\\:text-gray-800{--tw-text-opacity:1;color:#1f2937;color:rgba(31,41,55,var(--tw-text-opacity))}}',
-    '@media (min-width: 768px){.md\\:text-pink-700{--tw-text-opacity:1;color:#be185d;color:rgba(190,24,93,var(--tw-text-opacity))}}',
+    '@media (min-width:640px){.sm\\:text-gray-800{--tw-text-opacity:1;color:#1f2937;color:rgba(31,41,55,var(--tw-text-opacity))}}',
+    '@media (min-width:768px){.md\\:text-pink-700{--tw-text-opacity:1;color:#be185d;color:rgba(190,24,93,var(--tw-text-opacity))}}',
   ])
 })
 

--- a/src/twind/decorate.ts
+++ b/src/twind/decorate.ts
@@ -1,6 +1,6 @@
 import type { Context, CSSRules, Rule, DarkMode } from '../types'
 
-import { tail, escape } from '../internal/util'
+import { tail, escape, buildMediaQuery } from '../internal/util'
 
 // Wraps a CSS rule object with variant at-rules and pseudo classes
 // { '.selector': {...} }
@@ -14,10 +14,10 @@ export const decorate = (
   // Select the wrapper for a variant
   const applyVariant = (translation: CSSRules, variant: string): CSSRules => {
     // Check responsive
-    const size = theme('screens', tail(variant), '')
+    const screen = theme('screens', tail(variant), '')
 
-    if (size) {
-      return { [`@media (min-width: ${size})`]: translation }
+    if (screen) {
+      return { [buildMediaQuery(screen)]: translation }
     }
 
     // Dark mode

--- a/src/twind/plugins.ts
+++ b/src/twind/plugins.ts
@@ -9,17 +9,18 @@ import type {
   Context,
   Falsy,
   ThemeContainer,
+  ThemeScreen,
 } from '../types'
 
 import * as is from '../internal/is'
 
-import { includes, join, joinTruthy, tail, capitalize } from '../internal/util'
+import { includes, join, joinTruthy, tail, capitalize, buildMediaQuery } from '../internal/util'
 import { corners, expandEdges, edges } from './helpers'
 
 // Shared variables
 let _: undefined | string | CSSRules | CSSProperties | string[] | boolean | Falsy | number
 let __: undefined | string | CSSProperties
-let $: undefined | string | number
+let $: undefined | string | number | ThemeScreen
 
 const property = (property: string) => (
   params: string[],
@@ -881,10 +882,10 @@ export const corePlugins: Plugins = {
 
     return Object.keys(screens).reduce(
       (rules, screen) => {
-        if ((_ = screens[screen])) {
-          rules[`@media (min-width: ${_})`] = {
+        if (($ = screens[screen]) && is.string($)) {
+          rules[buildMediaQuery($)] = {
             '&': {
-              'max-width': _,
+              'max-width': $,
               ...paddingFor(screen),
             },
           }

--- a/src/twind/presedence.ts
+++ b/src/twind/presedence.ts
@@ -68,12 +68,12 @@ Allows single declaration styles to overwrite styles from multi declaration styl
 Ensure shorthand properties are inserted before longhand properties; eg longhand override shorthand
 */
 
-import type { ThemeResolver } from '../types'
+import type { ThemeResolver, ThemeScreen } from '../types'
 
-import { tail, includes } from '../internal/util'
+import { tail, includes, buildMediaQuery } from '../internal/util'
 
 // Shared variables
-let _: string | RegExpExecArray | null | number
+let _: string | RegExpExecArray | null | number | ThemeScreen
 
 /*
 Bit shifts for the primary bits:
@@ -176,7 +176,7 @@ export const makeVariantPresedenceCalculator = (
       // 36rem -> 3
       // 96rem -> 9
       // Move into screens layer and adjust based on min-width
-      (1 << 27) | responsivePrecedence(_)
+      (1 << 27) | responsivePrecedence(buildMediaQuery(_))
     : // 1: dark mode flag
     variant === ':dark'
     ? 1 << 30

--- a/src/twind/theme.ts
+++ b/src/twind/theme.ts
@@ -751,12 +751,14 @@ const resolveContext: ThemeSectionResolverContext = {
   // Stub implementation as negated values are automatically infered and do _not_ not to be in the theme
   negative: () => ({}),
 
-  breakpoints: (source) =>
-    Object.keys(source).reduce((target, key) => {
-      target['screen-' + key] = source[key]
+  breakpoints: (screens) =>
+    Object.keys(screens)
+      .filter((key) => is.string(screens[key]))
+      .reduce((target, key) => {
+        target['screen-' + key] = screens[key] as string
 
-      return target
-    }, {} as Record<string, string | undefined>),
+        return target
+      }, {} as Record<string, string | undefined>),
 }
 
 export const makeThemeResolver = (config?: ThemeConfiguration): ThemeResolver => {

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -1,4 +1,5 @@
 import type { CSSProperties } from './css'
+import type { MaybeArray } from './util'
 
 export interface ThemeResolver {
   <Section extends keyof Theme>(section: Section): Record<string, ThemeSectionType<Theme[Section]>>
@@ -69,7 +70,7 @@ export interface ThemeSectionResolverContext {
   ) => Record<string, string | undefined>
 
   readonly breakpoints: (
-    records: Record<string, string | undefined>,
+    records: Record<string, ThemeScreen | undefined>,
   ) => Record<string, string | undefined>
 }
 
@@ -87,6 +88,14 @@ export interface ThemeContainer {
   center?: boolean
   padding?: string | Record<string, string | undefined>
 }
+
+export type ThemeScreenValue =
+  | string
+  | { raw: string }
+  | { min: string; max?: string }
+  | { min?: string; max: string }
+
+export type ThemeScreen = MaybeArray<ThemeScreenValue>
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ThemeColorObject extends Record<string, ThemeColor> {
@@ -107,7 +116,7 @@ export interface Theme {
   spacing: ThemeSection
   durations: ThemeSection<string | string[]>
 
-  screens: ThemeSection
+  screens: ThemeSection<ThemeScreen>
 
   animation: ThemeSection<string | string[]>
   backgroundColor: ThemeSection<ThemeColor>

--- a/src/types/util.ts
+++ b/src/types/util.ts
@@ -1,1 +1,3 @@
 export type Falsy = '' | 0 | -0 | false | null | undefined | void
+
+export type MaybeArray<T> = T | readonly T[]


### PR DESCRIPTION
Support more Tailwind [breakpoints](https://tailwindcss.com/docs/breakpoints) in theme screens

```js
setup({
    theme: {
      extend: {
        screens: {
          standalone: { raw: '(display-mode:standalone)' },
          portrait: { raw: '(orientation: portrait)' },
          print: { raw: 'print' },
          special: [
            // Sidebar appears at 768px, so revert to `sm:` styles between 768px
            // and 868px, after which the main content area is wide enough again to
            // apply the `md:` styles.
            { min: '668px', max: '767px' },
            { min: '868px' },
          ],
        },
      },
    },
})

tw`standalone:text-black`
tw`portraitt:text-black`
tw`print:text-black`
tw`special:text-black`
```

Fixes #20

/cc @tw-in-js/contributors 