### PR TITLE
fix: allow to access the theme via tw.theme

### DIFF
--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -809,4 +809,9 @@ test('same style in different layers has different hash', ({ tw, sheet }) => {
   ])
 })
 
+test('tw.theme', ({ tw, sheet }) => {
+  assert.is(tw.theme('colors.red.500'), '#ef4444')
+  assert.equal(sheet.target, [])
+})
+
 test.run()

--- a/src/types/twind.ts
+++ b/src/types/twind.ts
@@ -4,14 +4,20 @@ import type { CSSProperties } from './css'
 import type { Theme, ThemeResolver, ThemeSectionType } from './theme'
 import type { Falsy } from './util'
 
-export interface TW {
+export interface TWCallable {
   (strings: TemplateStringsArray, ...interpolations: Token[]): string
   (...tokens: Token[]): string
 }
 
+export interface TW extends TWCallable {
+  theme: ThemeResolver
+  // css: Context['css']
+  // tag: Context['tag']
+}
+
 export interface Context {
   /** Allow composition */
-  readonly tw: TW
+  readonly tw: TWCallable
 
   /** Access to theme values */
   readonly theme: ThemeResolver


### PR DESCRIPTION
This PR adds a `tw.theme` function to lookup theme values.

Later we can expose other context properties as well (like `css` for #96)