### PR TITLE
@screen and @apply

### DIFF
--- a/docs/getting-started/css-in-js.md
+++ b/docs/getting-started/css-in-js.md
@@ -148,6 +148,38 @@ css`
 `
 ```
 
+As a convenience Twind provides the `@apply` CSS rule:
+
+```js
+css`
+  @apply text-gray(700 dark:300);
+
+  p {
+    @apply my-5';
+  }
+
+  h1 {
+    @apply text(black dark:white hover:purple-500);
+  }
+`
+
+css`
+  @apply ${['font-bold', false && 'underline', 'py-2 px-4']};
+  color: fuchsia;
+`
+```
+
+`@apply can be use in the object notation as well:
+
+```js
+css({
+  '@apply': 'font-bold py-2 px-4 underline',
+  // '@apply': ['font-bold py-2 px-4', false && underline'],
+  color: 'fuchsia',
+  transform: 'translateY(-1px)',
+})
+```
+
 ### Accessing the theme
 
 Values of the CSS object maybe functions that are passed the context and should return the value to be used:
@@ -212,6 +244,27 @@ css(
   screen('xl', { /* ... */ }),
   screen('2xl', apply` ... `),
 )
+`
+```
+
+As a convenience Twind provides the `@screen` CSS rule:
+
+```js
+import { css, screen, apply } from 'twind/css'
+
+// With template literal
+css`
+  @screen sm {
+    /* ... */
+  }
+`
+
+// With object notation
+css({
+  '@screen md': {
+    /* ... */
+  }
+})
 `
 ```
 

--- a/docs/getting-started/css-in-js.md
+++ b/docs/getting-started/css-in-js.md
@@ -169,7 +169,7 @@ css`
 `
 ```
 
-`@apply can be use in the object notation as well:
+`@apply can be used in the object notation as well:
 
 ```js
 css({

--- a/docs/getting-started/css-in-js.md
+++ b/docs/getting-started/css-in-js.md
@@ -247,7 +247,7 @@ css(
 `
 ```
 
-As a convenience Twind provides the `@screen` CSS rule:
+For convenience, Twind provides the `@screen` CSS rule:
 
 ```js
 import { css, screen, apply } from 'twind/css'

--- a/docs/getting-started/css-in-js.md
+++ b/docs/getting-started/css-in-js.md
@@ -148,7 +148,7 @@ css`
 `
 ```
 
-As a convenience Twind provides the `@apply` CSS rule:
+For convenience, Twind provides the `@apply` CSS rule:
 
 ```js
 css`

--- a/docs/getting-started/css-in-js.md
+++ b/docs/getting-started/css-in-js.md
@@ -155,7 +155,7 @@ css`
   @apply text-gray(700 dark:300);
 
   p {
-    @apply my-5';
+    @apply my-5;
   }
 
   h1 {

--- a/docs/getting-started/styling-with-twind.md
+++ b/docs/getting-started/styling-with-twind.md
@@ -107,7 +107,34 @@ tw({
 
 ## The apply function
 
-To be documented...
+Use {@link twind.apply | apply} to inline any existing utility classes into a single CSS class.
+
+This is useful when you find a common utility pattern in your HTML that you'd like to extract to a new component.
+
+```js
+import { apply } from 'twind'
+
+const btn = apply`inline-block bg-gray-500 text-base`
+// => generates on CSS class with all declarations of the above rules when used
+
+const btnBlock = apply`${btn} block`
+// => generates on CSS class with all declarations of btn & block
+
+<button class={tw`${btn}`}>gray-500</button>
+// => tw-XXXXX
+
+<button class={tw`${btn} bg-red-500 text-lg`}>red-500 large</button>
+// => tw-XXXX bg-red-500 text-lg
+
+<button class={tw`${btnBlock}`}>block button</button>
+// => tw-YYYY
+```
+
+The component styles are added **before** the utility classes to the stylesheet which allows utilities to override component styles.
+
+For more examples see the {@page Defining Components} guide.
+
+> 💡 Another way to extract common component styles is by {@page Plugins | using an alias plugin}.
 
 <hr/>
 

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -816,4 +816,53 @@ test('tw.theme', ({ tw, sheet }) => {
   assert.equal(sheet.target, [])
 })
 
+test('@screen (object notation)', ({ tw, sheet }) => {
+  const style = () => ({
+    '@screen sm': {
+      match: 'sm',
+    },
+    '@screen 2xl': {
+      '@apply': 'underline',
+    },
+  })
+
+  assert.equal(sheet.target, [])
+
+  assert.is(tw(style), 'tw-svjqbe')
+  assert.equal(sheet.target, [
+    '@media (min-width:640px){.tw-svjqbe{match:sm}}',
+    '@media (min-width:1536px){.tw-svjqbe{text-decoration:underline}}',
+  ])
+})
+
+test('@apply (object notation)', ({ tw, sheet }) => {
+  const style = () => ({
+    '@apply': 'font-bold py-2 px-4 underline',
+    color: 'fuchsia',
+    transform: 'translateY(-1px)',
+  })
+
+  assert.equal(sheet.target, [])
+
+  assert.is(tw(style), 'tw-1dlm15h')
+  assert.equal(sheet.target, [
+    '.tw-1dlm15h{font-weight:700;padding-bottom:0.5rem;padding-top:0.5rem;padding-left:1rem;padding-right:1rem;text-decoration:underline;color:fuchsia;transform:translateY(-1px)}',
+  ])
+})
+
+test('using @apply with array', ({ tw, sheet }) => {
+  const style = () => ({
+    '@apply': ['font-bold underline', false, undefined, 'py-2 px-4'],
+    color: 'fuchsia',
+    transform: 'translateY(-1px)',
+  })
+
+  assert.equal(sheet.target, [])
+
+  assert.is(tw(style), 'tw-v9zanm')
+  assert.equal(sheet.target, [
+    '.tw-v9zanm{font-weight:700;text-decoration:underline;padding-bottom:0.5rem;padding-top:0.5rem;padding-left:1rem;padding-right:1rem;color:fuchsia;transform:translateY(-1px)}',
+  ])
+})
+
 test.run()

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -865,4 +865,22 @@ test('using @apply with array', ({ tw, sheet }) => {
   ])
 })
 
+test('using @apply with variant', ({ tw, sheet }) => {
+  const style = () => ({
+    '@apply': 'font-bold hover:underline',
+    color: 'fuchsia',
+    '&:hover': {
+      transform: 'translateY(-1px)',
+    },
+  })
+
+  assert.equal(sheet.target, [])
+
+  assert.is(tw(style), 'tw-1plavv4')
+  assert.equal(sheet.target, [
+    '.tw-1plavv4:hover{text-decoration:underline;transform:translateY(-1px)}',
+    '.tw-1plavv4{font-weight:700;color:fuchsia}',
+  ])
+})
+
 test.run()

--- a/src/css/css.test.ts
+++ b/src/css/css.test.ts
@@ -733,4 +733,38 @@ test('screen directive (object notation)', ({ tw, sheet }) => {
   ])
 })
 
+test('@screen (template literal)', ({ tw, sheet }) => {
+  const style = css`
+    @screen sm {
+      match: sm;
+    }
+    @screen 2xl {
+      @apply underline;
+    }
+  `
+
+  assert.equal(sheet.target, [])
+
+  assert.is(tw(style), 'tw-svjqbe')
+  assert.equal(sheet.target, [
+    '@media (min-width:640px){.tw-svjqbe{match:sm}}',
+    '@media (min-width:1536px){.tw-svjqbe{text-decoration:underline}}',
+  ])
+})
+
+test('@apply (template literal)', ({ tw, sheet }) => {
+  const style = css`
+    @apply font-bold py-2 px-4 underline;
+    color: fuchsia;
+    transform: translateY(-1px);
+  `
+
+  assert.equal(sheet.target, [])
+
+  assert.is(tw(style), 'tw-1dlm15h')
+  assert.equal(sheet.target, [
+    '.tw-1dlm15h{font-weight:700;padding-bottom:0.5rem;padding-top:0.5rem;padding-left:1rem;padding-right:1rem;text-decoration:underline;color:fuchsia;transform:translateY(-1px)}',
+  ])
+})
+
 test.run()

--- a/src/css/css.test.ts
+++ b/src/css/css.test.ts
@@ -797,4 +797,29 @@ test('using @apply with array', ({ tw, sheet }) => {
   ])
 })
 
+test('@apply from docs', ({ tw, sheet }) => {
+  const style = css`
+    @apply text-gray(700 dark:300);
+
+    p {
+      @apply my-5;
+    }
+
+    h1 {
+      @apply text(black dark:white hover:purple-500);
+    }
+  `
+
+  assert.equal(sheet.target, [])
+
+  assert.is(tw(style), 'tw-ckdto4')
+  assert.equal(sheet.target, [
+    '.tw-ckdto4 h1:hover{--tw-text-opacity:1;color:#8b5cf6;color:rgba(139,92,246,var(--tw-text-opacity))}',
+    '.tw-ckdto4 h1{--tw-text-opacity:1;color:#000;color:rgba(0,0,0,var(--tw-text-opacity))}',
+    '.tw-ckdto4{--tw-text-opacity:1;color:#374151;color:rgba(55,65,81,var(--tw-text-opacity))}',
+    '.tw-ckdto4 p{margin-bottom:1.25rem;margin-top:1.25rem}',
+    '@media (prefers-color-scheme:dark){.tw-ckdto4{--tw-text-opacity:1;color:#d1d5db;color:rgba(209,213,219,var(--tw-text-opacity))}}',
+    '@media (prefers-color-scheme:dark){.tw-ckdto4 h1{--tw-text-opacity:1;color:#fff;color:rgba(255,255,255,var(--tw-text-opacity))}}',
+  ])
+})
 test.run()

--- a/src/css/css.test.ts
+++ b/src/css/css.test.ts
@@ -745,10 +745,10 @@ test('@screen (template literal)', ({ tw, sheet }) => {
 
   assert.equal(sheet.target, [])
 
-  assert.is(tw(style), 'tw-svjqbe')
+  assert.is(tw(style), 'tw-qku2fp')
   assert.equal(sheet.target, [
-    '@media (min-width:640px){.tw-svjqbe{match:sm}}',
-    '@media (min-width:1536px){.tw-svjqbe{text-decoration:underline}}',
+    '@media (min-width:640px){.tw-qku2fp{match:sm}}',
+    '@media (min-width:1536px){.tw-qku2fp{text-decoration:underline}}',
   ])
 })
 
@@ -761,9 +761,39 @@ test('@apply (template literal)', ({ tw, sheet }) => {
 
   assert.equal(sheet.target, [])
 
-  assert.is(tw(style), 'tw-1dlm15h')
+  assert.is(tw(style), 'tw-jvkskb')
   assert.equal(sheet.target, [
-    '.tw-1dlm15h{font-weight:700;padding-bottom:0.5rem;padding-top:0.5rem;padding-left:1rem;padding-right:1rem;text-decoration:underline;color:fuchsia;transform:translateY(-1px)}',
+    '.tw-jvkskb{font-weight:700;padding-bottom:0.5rem;padding-top:0.5rem;padding-left:1rem;padding-right:1rem;text-decoration:underline;color:fuchsia;transform:translateY(-1px)}',
+  ])
+})
+
+test('using several @apply', ({ tw, sheet }) => {
+  const style = css`
+    @apply font-bold underline;
+    color: fuchsia;
+    @apply py-2 px-4;
+    transform: translateY(-1px);
+  `
+
+  assert.equal(sheet.target, [])
+
+  assert.is(tw(style), 'tw-3sz6jf')
+  assert.equal(sheet.target, [
+    '.tw-3sz6jf{font-weight:700;text-decoration:underline;color:fuchsia;padding-bottom:0.5rem;padding-top:0.5rem;padding-left:1rem;padding-right:1rem;transform:translateY(-1px)}',
+  ])
+})
+
+test('using @apply with array', ({ tw, sheet }) => {
+  const style = css`
+    @apply ${['font-bold', false && 'underline', 'py-2 px-4']};
+    color: fuchsia;
+  `
+
+  assert.equal(sheet.target, [])
+
+  assert.is(tw(style), 'tw-1lxwuho')
+  assert.equal(sheet.target, [
+    '.tw-1lxwuho{font-weight:700;padding-bottom:0.5rem;padding-top:0.5rem;padding-left:1rem;padding-right:1rem;color:fuchsia}',
   ])
 })
 

--- a/src/css/index.ts
+++ b/src/css/index.ts
@@ -17,7 +17,7 @@ import type {
   ThemeScreenValue,
 } from '../types'
 
-import { hash, directive } from '../index'
+import { apply, hash, directive } from '../index'
 import { evalThunk, merge, buildMediaQuery } from '../internal/util'
 
 export { tw, apply, setup, theme } from '../index'

--- a/src/twind/configure.ts
+++ b/src/twind/configure.ts
@@ -10,6 +10,7 @@ import type {
   CSSRules,
   Mode,
   Falsy,
+  TypescriptCompat,
 } from '../types'
 
 import { corePlugins } from './plugins'
@@ -143,7 +144,7 @@ export const configure = (
   // Wrap `translate()` to keep track of the active rule
   // we need to use try-finally as mode.report may throw
   // and we must always reset the active rule
-  const doTranslate = (rule: Rule): CSSRules | string | Falsy => {
+  const doTranslate = (rule: Rule): CSSRules | string | Falsy | TypescriptCompat => {
     // Keep track of active variants for nested `tw` calls
     const parentRule = activeRule
     activeRule = rule

--- a/src/twind/serialize.ts
+++ b/src/twind/serialize.ts
@@ -1,6 +1,14 @@
 import type { Context, CSSRules, Prefixer, Rule } from '../types'
 
-import { join, includes, escape, hyphenate, evalThunk } from '../internal/util'
+import {
+  join,
+  includes,
+  escape,
+  hyphenate,
+  evalThunk,
+  buildMediaQuery,
+  tail,
+} from '../internal/util'
 import {
   responsivePrecedence,
   declarationPropertyPrecedence,
@@ -105,6 +113,10 @@ export const serialize = (
     // more specfic utilities have less declarations and a higher presedence
     let numberOfDeclarations = 0
 
+    if (typeof css['@apply'] == 'string') {
+      css = { ...context.css(css['@apply']), ...css, '@apply': undefined }
+    }
+
     // Walk through the object
     Object.keys(css).forEach((key) => {
       const value = evalThunk(css[key], context)
@@ -162,6 +174,10 @@ export const serialize = (
               p: waypoints.reduce((sum, p) => sum + p.p, 0),
             })
           } else {
+            if (key.slice(1, 8) == 'screen ') {
+              key = buildMediaQuery(context.theme('screens', tail(key, 8).trim()) as string)
+            }
+
             // Some nested block like @media, dive into it
             stringify(
               [...atRules, key],

--- a/src/twind/serialize.ts
+++ b/src/twind/serialize.ts
@@ -1,4 +1,4 @@
-import type { Context, CSSRules, Prefixer, Rule } from '../types'
+import type { Context, CSSRules, Prefixer, Rule, Token } from '../types'
 
 import {
   join,
@@ -15,7 +15,7 @@ import {
   makeVariantPresedenceCalculator,
   atRulePresedence,
 } from './presedence'
-
+import { apply } from './apply'
 export interface RuleWithPresedence {
   r: string
   p: number
@@ -113,8 +113,8 @@ export const serialize = (
     // more specfic utilities have less declarations and a higher presedence
     let numberOfDeclarations = 0
 
-    if (typeof css['@apply'] == 'string') {
-      css = { ...context.css(css['@apply']), ...css, '@apply': undefined }
+    if (typeof css['@apply'] != 'undefined') {
+      css = { ...evalThunk(apply(css['@apply'] as Token), context), ...css, '@apply': undefined }
     }
 
     // Walk through the object

--- a/src/twind/serialize.ts
+++ b/src/twind/serialize.ts
@@ -8,6 +8,7 @@ import {
   evalThunk,
   buildMediaQuery,
   tail,
+  merge,
 } from '../internal/util'
 import {
   responsivePrecedence,
@@ -113,8 +114,12 @@ export const serialize = (
     // more specfic utilities have less declarations and a higher presedence
     let numberOfDeclarations = 0
 
-    if (typeof css['@apply'] != 'undefined') {
-      css = { ...evalThunk(apply(css['@apply'] as Token), context), ...css, '@apply': undefined }
+    if ('@apply' in css) {
+      css = merge(
+        evalThunk(apply(css['@apply'] as Token), context),
+        { ...css, '@apply': undefined },
+        context,
+      )
     }
 
     // Walk through the object

--- a/src/twind/translate.ts
+++ b/src/twind/translate.ts
@@ -1,14 +1,22 @@
-import type { Context, CSSRules, Plugins, Rule, Falsy, InlineDirective } from '../types'
+import type {
+  Context,
+  CSSRules,
+  Plugins,
+  Rule,
+  Falsy,
+  InlineDirective,
+  TypescriptCompat,
+} from '../types'
 
 import { join, tail } from '../internal/util'
 
 export const translate = (
   plugins: Plugins,
   context: Context,
-): ((rule: Rule, isTranslating?: boolean) => InlineDirective | CSSRules | string | Falsy) => (
-  rule,
-  isTranslating,
-) => {
+): ((
+  rule: Rule,
+  isTranslating?: boolean,
+) => InlineDirective | CSSRules | string | Falsy | TypescriptCompat) => (rule, isTranslating) => {
   // If this is a inline directive - called it right away
   if (typeof rule.d == 'function') {
     return rule.d(context)

--- a/src/types/twind.ts
+++ b/src/types/twind.ts
@@ -2,7 +2,7 @@ import type * as CSS from 'csstype'
 
 import type { CSSProperties } from './css'
 import type { Theme, ThemeResolver, ThemeSectionType } from './theme'
-import type { Falsy } from './util'
+import type { Falsy, MaybeArray } from './util'
 
 export interface TWCallable {
   (strings: TemplateStringsArray, ...interpolations: Token[]): string
@@ -190,7 +190,7 @@ export interface Directive<T> {
 }
 
 export interface InlineDirective {
-  (context: Context): CSSRules | string | Falsy
+  (context: Context): CSSRules | string | Falsy | TypescriptCompat
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -250,6 +250,10 @@ export interface CSSRules {
   // ':root'?: CSSProperties
   // '*'?: CSSProperties
 
+  '@apply'?: MaybeArray<string | Falsy | TypescriptCompat>
+  global?: CSSRules | CSSRulesThunk
+  // [`@screen ${string}`]: MaybeArray<string | Falsy | TypescriptCompat>
+
   // TODO it would be great if we could use CSS Properties with mapped types to typechecked CSS rules
   [key: string]:
     | CSSProperties
@@ -257,9 +261,7 @@ export interface CSSRules {
     | CSSAtSupports
     | CSSAtKeyframes
     | CSSRules
-    | string
-    | string[]
-    | Falsy
+    | MaybeArray<string | Falsy | TypescriptCompat>
     | CSSRulesThunk
 }
 
@@ -271,7 +273,5 @@ export interface CSSRulesThunk {
     | CSSAtKeyframes
     | CSSRules
     | CSSRulesThunk
-    | string
-    | string[]
-    | Falsy
+    | MaybeArray<string | Falsy | TypescriptCompat>
 }


### PR DESCRIPTION
This PR adds `@screen` and `@apply` at-rules which work like their function counterparts [screen](https://twind.dev/docs/handbook/getting-started/css-in-js.html#screen-directive) and [apply](https://twind.dev/docs/handbook/getting-started/styling-with-twind.html#the-apply-function):

**@apply**

```js
// Object Notation
tw(() => ({
  '@apply': 'font-bold py-2 px-4 underline',
  // '@apply': ['font-bold py-2 px-4', false && underline'],
  color: 'fuchsia',
  transform: 'translateY(-1px)',
})

// with twind/css
css`
  @apply font-bold underline;
  color: fuchsia;
  @apply py-2 px-4;
  transform: translateY(-1px);
`

css`
  @apply ${['font-bold', false && 'underline', 'py-2 px-4']};
  color: fuchsia;
`
```


=>

```css
.tw-1dlm15h {
  font-weight: 700;
  padding-bottom: 0.5rem;
  padding-top: 0.5rem;
  padding-left: 1rem;
  padding-right: 1rem;
  text-decoration: underline;
  color: fuchsia;
  transform: translateY(-1px);
}
```

**@screen**

```js
// Object Notation
tw(() => ({
  '@screen 2xl': {
    '@apply': 'underline',
  },
})

// with twind/css
css`
  @screen 2xl {
    @apply underline;
  }
`
```

=>

```css
@media (min-width:1536px) {
  .tw-svjqbe {
    text-decoration:underline;
  }
}
```

/cc @tw-in-js/contributors 