### PR TITLE
Also apply space and divide rules to slotted content

### DIFF
--- a/src/twind/plugins.ts
+++ b/src/twind/plugins.ts
@@ -713,11 +713,13 @@ export const corePlugins: Plugins = {
       reversableEdge(params, context, id, 'divideWidth', 'border', 'width') ||
       border(params, context, id)) && {
       '&>:not([hidden])~:not([hidden])': _ as CSSRules,
+      '&>:not([hidden])~:not([hidden])::slotted(*)': _ as CSSRules,
     },
 
   space: (params, context, id) =>
     (_ = reversableEdge(params, context, id, 'space', 'margin')) && {
       '&>:not([hidden])~:not([hidden])': _,
+      '&>:not([hidden])~:not([hidden])::slotted(*)': _,
     },
 
   placeholder: (params, { theme }, id) =>


### PR DESCRIPTION
Twind and Web Components are a perfect match (thank you) but was facing issues with space-(x-y) and divide utilities and realised that those weren't properly applied to slotted content.

See repro here (not working, there should be a space-y-12 between `Hello` and `Worl`):

https://esm.codes/#aW1wb3J0IHsgTGl0RWxlbWVudCwgaHRtbCB9IGZyb20gJ2h0dHBzOi8vY2RuLnNreXBhY2suZGV2L2xpdC1lbGVtZW50JwppbXBvcnQgeyBjcmVhdGUsIGNzc29tU2hlZXQgfSBmcm9tICdodHRwczovL2Nkbi5za3lwYWNrLmRldi90d2luZCcKCmNvbnN0IHNoZWV0ID0gY3Nzb21TaGVldCh7IHRhcmdldDogbmV3IENTU1N0eWxlU2hlZXQoKSB9KQoKY29uc3QgeyB0dyB9ID0gY3JlYXRlKHsgc2hlZXQgfSkKCmNsYXNzIFR3aW5kRWxlbWVudCBleHRlbmRzIExpdEVsZW1lbnQgewogIGNyZWF0ZVJlbmRlclJvb3QoKSB7CiAgICBjb25zdCBzaGFkb3cgPSBzdXBlci5jcmVhdGVSZW5kZXJSb290KCkKICAgIHNoYWRvdy5hZG9wdGVkU3R5bGVTaGVldHMgPSBbc2hlZXQudGFyZ2V0XQogICAgcmV0dXJuIHNoYWRvdwogIH0KCiAgcmVuZGVyKCkgewogICAgcmV0dXJuIGh0bWxgCiAgICAgIDxtYWluIGNsYXNzPSIke3R3YGgtc2NyZWVuIGJnLXB1cnBsZS00MDAgZmxleCBmbGV4LWNvbCBpdGVtcy1jZW50ZXIganVzdGlmeS1jZW50ZXIgc3BhY2UteS0xMmB9Ij4KICAgICAgICA8aDEgY2xhc3M9IiR7dHdgZm9udC1ib2xkIHRleHQoY2VudGVyIDV4bCB3aGl0ZSBzbTpncmF5LTgwMCBtZDpwaW5rLTcwMClgfSI+CiAgICAgICAgICBUaGlzIGlzIFR3aW5kIQogICAgICAgIDwvaDE+CiAgICAgICAgPGRpdiBjbGFzcz0iJHt0d2BmbGV4IGZsZXgtY29sIHNwYWNlLXktMTJgfSI+CiAgICAgICAgICA8c2xvdCBuYW1lPSJlbGVtZW50LTEiPjwvc2xvdD4KICAgICAgICAgIDxzbG90IG5hbWU9ImVsZW1lbnQtMiI+PC9zbG90PgogICAgICAgIDxkaXY+CiAgICAgIDwvbWFpbj4KICAgIGAKICB9Cn0KCmN1c3RvbUVsZW1lbnRzLmRlZmluZSgndHdpbmQtZWxlbWVudCcsIFR3aW5kRWxlbWVudCk7Cgpkb2N1bWVudC5ib2R5LmlubmVySFRNTCA9IGAKIDx0d2luZC1lbGVtZW50PgogICAgPGRpdiBzbG90PSJlbGVtZW50LTEiPkhlbGxvPC9kaXY+CiAgICA8ZGl2IHNsb3Q9ImVsZW1lbnQtMiI+V29ybDwvZGl2PgogIDwvdHdpbmQtZWxlbWVudD4KYAo=

<img width="964" alt="Screen Shot 2021-02-14 at 10 01 45 am" src="https://user-images.githubusercontent.com/21725/107863885-ab758200-6eab-11eb-9ee1-af19c21353e4.png">


With this fix:

https://esm.codes/#aW1wb3J0IHsgTGl0RWxlbWVudCwgaHRtbCB9IGZyb20gJ2h0dHBzOi8vY2RuLnNreXBhY2suZGV2L2xpdC1lbGVtZW50JwppbXBvcnQgeyBjcmVhdGUsIGNzc29tU2hlZXQgfSBmcm9tICdodHRwczovL2Nkbi5za3lwYWNrLmRldi9AZGJsZWNob2MvdHdpbmQnCgpjb25zdCBzaGVldCA9IGNzc29tU2hlZXQoeyB0YXJnZXQ6IG5ldyBDU1NTdHlsZVNoZWV0KCkgfSkKCmNvbnN0IHsgdHcgfSA9IGNyZWF0ZSh7IHNoZWV0IH0pCgpjbGFzcyBUd2luZEVsZW1lbnQgZXh0ZW5kcyBMaXRFbGVtZW50IHsKICBjcmVhdGVSZW5kZXJSb290KCkgewogICAgY29uc3Qgc2hhZG93ID0gc3VwZXIuY3JlYXRlUmVuZGVyUm9vdCgpCiAgICBzaGFkb3cuYWRvcHRlZFN0eWxlU2hlZXRzID0gW3NoZWV0LnRhcmdldF0KICAgIHJldHVybiBzaGFkb3cKICB9CgogIHJlbmRlcigpIHsKICAgIHJldHVybiBodG1sYAogICAgICA8bWFpbiBjbGFzcz0iJHt0d2BoLXNjcmVlbiBiZy1wdXJwbGUtNDAwIGZsZXggZmxleC1jb2wgaXRlbXMtY2VudGVyIGp1c3RpZnktY2VudGVyIHNwYWNlLXktMTJgfSI+CiAgICAgICAgPGgxIGNsYXNzPSIke3R3YGZvbnQtYm9sZCB0ZXh0KGNlbnRlciA1eGwgd2hpdGUgc206Z3JheS04MDAgbWQ6cGluay03MDApYH0iPgogICAgICAgICAgVGhpcyBpcyBUd2luZCEKICAgICAgICA8L2gxPgogICAgICAgIDxkaXYgY2xhc3M9IiR7dHdgZmxleCBmbGV4LWNvbCBzcGFjZS15LTEyYH0iPgogICAgICAgICAgPHNsb3QgbmFtZT0iZWxlbWVudC0xIj48L3Nsb3Q+CiAgICAgICAgICA8c2xvdCBuYW1lPSJlbGVtZW50LTIiPjwvc2xvdD4KICAgICAgICA8ZGl2PgogICAgICA8L21haW4+CiAgICBgCiAgfQp9CgpjdXN0b21FbGVtZW50cy5kZWZpbmUoJ3R3aW5kLWVsZW1lbnQnLCBUd2luZEVsZW1lbnQpOwoKZG9jdW1lbnQuYm9keS5pbm5lckhUTUwgPSBgCiA8dHdpbmQtZWxlbWVudD4KICAgIDxkaXYgc2xvdD0iZWxlbWVudC0xIj5IZWxsbzwvZGl2PgogICAgPGRpdiBzbG90PSJlbGVtZW50LTIiPldvcmw8L2Rpdj4KICA8L3R3aW5kLWVsZW1lbnQ+CmAK

<img width="964" alt="Screen Shot 2021-02-14 at 10 02 10 am" src="https://user-images.githubusercontent.com/21725/107863895-bcbe8e80-6eab-11eb-9830-10c0fec6ea6f.png">

