### PR TITLE
fix: support several @font-face rules

### DIFF
--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -703,7 +703,7 @@ test('inject @font-face', ({ sheet, tw }) => {
   ])
 })
 
-test('inject global styles', ({ sheet, tw }) => {
+test('inject :global styles', ({ sheet, tw }) => {
   assert.is(
     tw(() => ({
       ':global': {
@@ -719,6 +719,25 @@ test('inject global styles', ({ sheet, tw }) => {
   assert.equal(sheet.target, [
     ':root{--main-bg-color:brown}',
     '.tw-tmrj30{background-color:var(--main-bg-color)}',
+  ])
+})
+
+test('inject @global styles', ({ sheet, tw }) => {
+  assert.is(
+    tw(() => ({
+      '@global': {
+        ':root': {
+          '--main-bg-color': 'brown',
+        },
+      },
+      backgroundColor: 'var(--main-bg-color)',
+    })),
+    'tw-1uumlz8',
+  )
+
+  assert.equal(sheet.target, [
+    ':root{--main-bg-color:brown}',
+    '.tw-1uumlz8{background-color:var(--main-bg-color)}',
   ])
 })
 
@@ -776,6 +795,20 @@ test('use :global', ({ tw, sheet }) => {
   })
 
   assert.is(tw(style), 'tw-1wz18eh')
+
+  assert.equal(sheet.target, ['html{background-color:#111827}'])
+})
+
+test('use @global', ({ tw, sheet }) => {
+  const style: InlineDirective = ({ theme }) => ({
+    '@global': {
+      html: {
+        backgroundColor: theme('colors.gray.900'),
+      },
+    },
+  })
+
+  assert.is(tw(style), 'tw-eqyrrl')
 
   assert.equal(sheet.target, ['html{background-color:#111827}'])
 })
@@ -905,6 +938,20 @@ test('using @font-face with array', ({ tw, sheet }) => {
   assert.equal(sheet.target, [
     '@font-face{font-family:Proxima Nova;font-weight:400;src:url(/fonts/proxima-nova/400-regular.woff) format("woff")}',
     '@font-face{font-family:Proxima Nova;font-weight:500;src:url(/fonts/proxima-nova/500-medium.woff) format("woff")}',
+  ])
+})
+
+test('using @import with array', ({ tw, sheet }) => {
+  const style = () => ({
+    '@import': [`'custom.css'`, `url('landscape.css') screen and (orientation:landscape)`],
+  })
+
+  assert.equal(sheet.target, [])
+
+  tw(style)
+  assert.equal(sheet.target, [
+    "@import 'custom.css';",
+    "@import url('landscape.css') screen and (orientation:landscape);",
   ])
 })
 

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -883,4 +883,29 @@ test('using @apply with variant', ({ tw, sheet }) => {
   ])
 })
 
+test('using @font-face with array', ({ tw, sheet }) => {
+  const style = () => ({
+    '@font-face': [
+      {
+        fontFamily: 'Proxima Nova',
+        fontWeight: '400',
+        src: 'url(/fonts/proxima-nova/400-regular.woff) format("woff")',
+      },
+      {
+        fontFamily: 'Proxima Nova',
+        fontWeight: '500',
+        src: 'url(/fonts/proxima-nova/500-medium.woff) format("woff")',
+      },
+    ],
+  })
+
+  assert.equal(sheet.target, [])
+
+  tw(style)
+  assert.equal(sheet.target, [
+    '@font-face{font-family:Proxima Nova;font-weight:400;src:url(/fonts/proxima-nova/400-regular.woff) format("woff")}',
+    '@font-face{font-family:Proxima Nova;font-weight:500;src:url(/fonts/proxima-nova/500-medium.woff) format("woff")}',
+  ])
+})
+
 test.run()

--- a/src/__tests__/apply.test.ts
+++ b/src/__tests__/apply.test.ts
@@ -284,6 +284,20 @@ test('use :global', ({ tw, sheet }) => {
   ])
 })
 
+test('use @global', ({ tw, sheet }) => {
+  const style = () => ({
+    '@global': {
+      html: apply('bg-gray-900 text-white'),
+    },
+  })
+
+  assert.is(tw(style), 'tw-z31ttt')
+
+  assert.equal(sheet.target, [
+    'html{--tw-17cwy6m:1;background-color:#111827;background-color:rgba(17,24,39,var(--tw-17cwy6m));--tw-dxr4o8:1;color:#fff;color:rgba(255,255,255,var(--tw-dxr4o8))}',
+  ])
+})
+
 test('use :global within css', ({ tw, sheet }) => {
   const style = css({
     ':global': {
@@ -298,6 +312,23 @@ test('use :global within css', ({ tw, sheet }) => {
     'body{--tw-17cwy6m:1;background-color:#111827;background-color:rgba(17,24,39,var(--tw-17cwy6m));--tw-dxr4o8:1;color:#fff;color:rgba(255,255,255,var(--tw-dxr4o8))}',
     '.tw-49gfd9 a:hover{--tw-dxr4o8:1;color:#1d4ed8;color:rgba(29,78,216,var(--tw-dxr4o8))}',
     '.tw-49gfd9 a{--tw-dxr4o8:1;color:#3b82f6;color:rgba(59,130,246,var(--tw-dxr4o8))}',
+  ])
+})
+
+test('use @global within css', ({ tw, sheet }) => {
+  const style = css({
+    '@global': {
+      body: apply('bg-gray-900 text-white'),
+    },
+    a: apply('text-blue(500 hover:700)'),
+  })
+
+  assert.is(tw(style), 'tw-efetv')
+
+  assert.equal(sheet.target, [
+    'body{--tw-17cwy6m:1;background-color:#111827;background-color:rgba(17,24,39,var(--tw-17cwy6m));--tw-dxr4o8:1;color:#fff;color:rgba(255,255,255,var(--tw-dxr4o8))}',
+    '.tw-efetv a:hover{--tw-dxr4o8:1;color:#1d4ed8;color:rgba(29,78,216,var(--tw-dxr4o8))}',
+    '.tw-efetv a{--tw-dxr4o8:1;color:#3b82f6;color:rgba(59,130,246,var(--tw-dxr4o8))}',
   ])
 })
 

--- a/src/__tests__/preflight.test.ts
+++ b/src/__tests__/preflight.test.ts
@@ -128,15 +128,32 @@ test('use custom preflight JSON style', () => {
   create({
     sheet,
     preflight: {
-      '@font-face': {
-        'font-family': 'Baloo',
-        src: 'url(./Baloo-Regular.ttf)',
-      },
+      '@font-face': [
+        {
+          fontFamily: 'Proxima Nova',
+          fontWeight: '400',
+          src: 'url(/fonts/proxima-nova/400-regular.woff) format("woff")',
+        },
+        {
+          fontFamily: 'Proxima Nova',
+          fontWeight: '500',
+          src: 'url(/fonts/proxima-nova/500-medium.woff) format("woff")',
+        },
+      ],
     },
   })
 
-  assert.is(sheet.target.length, 38)
-  assert.ok(sheet.target.includes('@font-face{font-family:Baloo;src:url(./Baloo-Regular.ttf)}'))
+  assert.is(sheet.target.length, 39)
+  assert.ok(
+    sheet.target.includes(
+      '@font-face{font-family:Proxima Nova;font-weight:400;src:url(/fonts/proxima-nova/400-regular.woff) format("woff")}',
+    ),
+  )
+  assert.ok(
+    sheet.target.includes(
+      '@font-face{font-family:Proxima Nova;font-weight:500;src:url(/fonts/proxima-nova/500-medium.woff) format("woff")}',
+    ),
+  )
 })
 
 test.run()

--- a/src/css/css.test.ts
+++ b/src/css/css.test.ts
@@ -565,18 +565,18 @@ test('keyframes with apply', ({ tw, sheet }) => {
       }
       70% {
         @apply transform-gpu -translate-x-3.5;
-      },
+      }
       90% {
         @apply transform-gpu -translate-x-1;
       }
     `,
   )
 
-  assert.is(tw(bounce), 'tw-1pb2it5')
+  assert.is(tw(bounce), 'tw-1ove4r3')
 
   assert.equal(sheet.target, [
-    '@keyframes tw-p4d614{from, 20%, 53%, 80%, to{--tw-translate-x:0px;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;transform:translateX(0px);transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}40%, 43%{--tw-translate-x:calc(1.75rem * -1);--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;transform:translateX(calc(1.75rem * -1));transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}70%{--tw-translate-x:calc(0.875rem * -1);--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;transform:translateX(calc(0.875rem * -1));transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}, 90%{--tw-translate-x:calc(0.25rem * -1);--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;transform:translateX(calc(0.25rem * -1));transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}}',
-    '.tw-1pb2it5{animation:1s ease infinite;animation-name:tw-p4d614}',
+    '@keyframes tw-1twhlfv{from, 20%, 53%, 80%, to{--tw-translate-x:0px;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;transform:translateX(0px);transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}40%, 43%{--tw-translate-x:calc(1.75rem * -1);--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;transform:translateX(calc(1.75rem * -1));transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}70%{--tw-translate-x:calc(0.875rem * -1);--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;transform:translateX(calc(0.875rem * -1));transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}90%{--tw-translate-x:calc(0.25rem * -1);--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;transform:translateX(calc(0.25rem * -1));transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}}',
+    '.tw-1ove4r3{animation:1s ease infinite;animation-name:tw-1twhlfv}',
   ])
 })
 

--- a/src/css/css.test.ts
+++ b/src/css/css.test.ts
@@ -822,4 +822,28 @@ test('@apply from docs', ({ tw, sheet }) => {
     '@media (prefers-color-scheme:dark){.tw-ckdto4 h1{--tw-text-opacity:1;color:#fff;color:rgba(255,255,255,var(--tw-text-opacity))}}',
   ])
 })
+
+test('using @font-apply', ({ tw, sheet }) => {
+  const style = css`
+    @font-face {
+      font-family: Proxima Nova;
+      font-weight: 400;
+      src: url(/fonts/proxima-nova/400-regular.woff) format('woff');
+    }
+    @font-face {
+      font-family: Proxima Nova;
+      font-weight: 500;
+      src: url(/fonts/proxima-nova/500-medium.woff) format('woff');
+    }
+  `
+
+  assert.equal(sheet.target, [])
+
+  tw(style)
+  assert.equal(sheet.target, [
+    "@font-face{font-family:Proxima Nova;font-weight:400;src:url(/fonts/proxima-nova/400-regular.woff) format('woff')}",
+    "@font-face{font-family:Proxima Nova;font-weight:500;src:url(/fonts/proxima-nova/500-medium.woff) format('woff')}",
+  ])
+})
+
 test.run()

--- a/src/internal/util.ts
+++ b/src/internal/util.ts
@@ -55,8 +55,14 @@ export const merge = (target: CSSRules, source: CSSRules, context: Context): CSS
     ? Object.keys(source).reduce((target, key) => {
         const value = evalThunk(source[key], context)
 
-        if (value && typeof value == 'object' && !Array.isArray(value)) {
-          target[key] = merge((target[key] || {}) as CSSRules, value as CSSRules, context)
+        if (value && typeof value == 'object' && !(Array.isArray(value) && !/[@:,(&]/.test(key))) {
+          // Keep all @font-face, @import, @global as is
+          if (/^@[fig]/.test(key)) {
+            // eslint-disable-next-line prettier/prettier
+            ((target[key] || (target[key] = [])) as CSSRules[]).push(value as CSSRules)
+          } else {
+            target[key] = merge((target[key] || {}) as CSSRules, value as CSSRules, context)
+          }
         } else {
           // hyphenate target key only if key is property like (\w-)
           target[hyphenate(key)] = value

--- a/src/types/css.ts
+++ b/src/types/css.ts
@@ -9,3 +9,7 @@ export interface CSSProperties
   extends CSS.PropertiesFallback<string, string>,
     CSS.PropertiesHyphenFallback<string, string>,
     CSSCustomProperties {}
+
+export interface FontFace
+  extends CSS.AtRule.FontFaceFallback<string, string>,
+    CSS.AtRule.FontFaceHyphenFallback<string, string> {}

--- a/src/types/twind.ts
+++ b/src/types/twind.ts
@@ -207,15 +207,17 @@ export type Token = string | TokenGrouping | InlineDirective | Token[] | Falsy |
  * watch out for ':root' - that could use '*' instead
  */
 // [`:${string}`]: CSSRules
-export type CSSSimplePseudos = { [K in CSS.SimplePseudos as `&${string & K}`]?: CSSRules }
+export type CSSSimplePseudos = {
+  [K in CSS.SimplePseudos as `&${string & K}`]?: CSSRulesThunk | MaybeArray<CSSRules>
+}
 
 export interface CSSPseudos extends CSSSimplePseudos {
   '&:nth-child(2n)'?: CSSRules
   '&:nth-child(odd)'?: CSSRules
 }
 
-export type CSSAtMedia = Record<string, CSSRules>
-export type CSSAtSupports = Record<string, CSSRules>
+export type CSSAtMedia = Record<string, MaybeArray<CSSRules>>
+export type CSSAtSupports = Record<string, MaybeArray<CSSRules>>
 export type CSSAtKeyframes = Record<string, CSSProperties | ((context: Context) => CSSProperties)>
 
 /**
@@ -250,8 +252,9 @@ export interface CSSRules {
   // ':root'?: CSSProperties
   // '*'?: CSSProperties
 
+  '@font-face'?: CSSRulesThunk | MaybeArray<CSSRules>
   '@apply'?: MaybeArray<string | Falsy | TypescriptCompat>
-  global?: CSSRules | CSSRulesThunk
+  ':global'?: CSSRulesThunk | MaybeArray<CSSRules>
   // [`@screen ${string}`]: MaybeArray<string | Falsy | TypescriptCompat>
 
   // TODO it would be great if we could use CSS Properties with mapped types to typechecked CSS rules
@@ -260,9 +263,8 @@ export interface CSSRules {
     | CSSAtMedia
     | CSSAtSupports
     | CSSAtKeyframes
-    | CSSRules
-    | MaybeArray<string | Falsy | TypescriptCompat>
     | CSSRulesThunk
+    | MaybeArray<CSSRules | string | Falsy | TypescriptCompat>
 }
 
 export interface CSSRulesThunk {
@@ -271,7 +273,6 @@ export interface CSSRulesThunk {
     | CSSAtMedia
     | CSSAtSupports
     | CSSAtKeyframes
-    | CSSRules
     | CSSRulesThunk
-    | MaybeArray<string | Falsy | TypescriptCompat>
+    | MaybeArray<CSSRules | string | Falsy | TypescriptCompat>
 }

--- a/src/types/twind.ts
+++ b/src/types/twind.ts
@@ -1,6 +1,6 @@
 import type * as CSS from 'csstype'
 
-import type { CSSProperties } from './css'
+import type { CSSProperties, FontFace } from './css'
 import type { Theme, ThemeResolver, ThemeSectionType } from './theme'
 import type { Falsy, MaybeArray } from './util'
 
@@ -252,27 +252,26 @@ export interface CSSRules {
   // ':root'?: CSSProperties
   // '*'?: CSSProperties
 
-  '@font-face'?: CSSRulesThunk | MaybeArray<CSSRules>
+  '@import'?: CSSRulesThunk<MaybeArray<string>> | MaybeArray<string>
+  '@font-face'?: CSSRulesThunk<MaybeArray<FontFace>> | MaybeArray<FontFace>
+  '@keyframes'?: CSSRulesThunk<CSSAtKeyframes> | CSSAtKeyframes
   '@apply'?: MaybeArray<string | Falsy | TypescriptCompat>
-  ':global'?: CSSRulesThunk | MaybeArray<CSSRules>
+  ':global'?: CSSRulesThunk<MaybeArray<CSSRules>> | MaybeArray<CSSRules>
+
+  // [`@media ${string}`]: MaybeArray<CSSRules>
   // [`@screen ${string}`]: MaybeArray<string | Falsy | TypescriptCompat>
 
   // TODO it would be great if we could use CSS Properties with mapped types to typechecked CSS rules
-  [key: string]:
-    | CSSProperties
-    | CSSAtMedia
-    | CSSAtSupports
-    | CSSAtKeyframes
-    | CSSRulesThunk
-    | MaybeArray<CSSRules | string | Falsy | TypescriptCompat>
+  [key: string]: CSSRuleValue
 }
 
-export interface CSSRulesThunk {
-  (context: Context):
-    | CSSProperties
-    | CSSAtMedia
-    | CSSAtSupports
-    | CSSAtKeyframes
-    | CSSRulesThunk
-    | MaybeArray<CSSRules | string | Falsy | TypescriptCompat>
+export type CSSRuleValue =
+  | CSSAtMedia
+  | CSSAtSupports
+  | CSSAtKeyframes
+  | CSSRulesThunk
+  | MaybeArray<CSSProperties | CSSRules | FontFace | string | Falsy | TypescriptCompat>
+
+export interface CSSRulesThunk<Value = CSSRuleValue> {
+  (context: Context): Value
 }


### PR DESCRIPTION
Add support for several `@font-face` rules:

```js
import { setup } from 'twind'

setup({
  theme: {
    extend: {
      fontFamily: {
        'proxima-nova': '"Proxima Nova"',
      },
    },
  },
  preflight: {
    '@font-face': [
      {
        fontFamily: 'Proxima Nova',
        fontWeight: '400',
        src: 'url(/fonts/proxima-nova/400-regular.woff) format("woff")',
      },
      {
        fontFamily: 'Proxima Nova',
        fontWeight: '500',
        src: 'url(/fonts/proxima-nova/500-medium.woff) format("woff")',
      },
    ]
  }
})
```

or using `css`:

```js
import { setup } from 'twind'
import { css } from 'twind/css'

setup({
  preflight: (preflight) =>
    css`
      ${preflight}

      @font-face {
        font-family: Proxima Nova;
        font-weight: 400;
        src: url(/fonts/proxima-nova/400-regular.woff) format("woff");
      }
      @font-face {
        font-family: Proxima Nova;
        font-weight: 500;
        src: url(/fonts/proxima-nova/500-medium.woff) format("woff");
      }
    `
})
```

Fixes #128 