### PR TITLE
feat: support arbitrary values using square bracket notation

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     {
       "path": "dist/twind.js",
       "gzip": true,
-      "limit": "12.7kb"
+      "limit": "12.8kb"
     },
     {
       "path": "dist/css/css.js",
@@ -89,11 +89,10 @@
     "@typescript-eslint/eslint-plugin": "^4.9.1",
     "@typescript-eslint/parser": "^4.9.1",
     "c8": "^7.3.5",
-    "distilt": "^0.10.1",
+    "distilt": "^0.10.2",
     "dlv": "^1.1.3",
     "doctoc": "^2.0.0",
-    "esbuild": "^0.8.31",
-    "esbuild-register": "^2.0.0",
+    "esbuild-register": "~2.2.1",
     "eslint": "^7.15.0",
     "eslint-config-prettier": "^7.0.0",
     "eslint-plugin-prettier": "^3.2.0",

--- a/src/__tests__/api.json
+++ b/src/__tests__/api.json
@@ -795,13 +795,77 @@
   "not-disabled:focus:font-bold": ".not-disabled\\:focus\\:font-bold:not(:disabled):focus{font-weight:700}",
   "not-logged-in:hidden": "body:not(.logged-in) .not-logged-in\\:hidden{display:none}",
   "not-last-child:mb-5": ".not-last-child\\:mb-5:not(:last-child){margin-bottom:1.25rem}",
+  "flex-[30%]": ".flex-\\[30\\%\\]{flex:30%}",
+  "border-[7px]": ".border-\\[7px\\]{border-width:7px}",
+  "border-[#1da1f2]": ".border-\\[\\#1da1f2\\]{--tw-border-opacity:1;border-color:#1da1f2;border-color:rgba(29,161,242,var(--tw-border-opacity))}",
   "top-[123px]": ".top-\\[123px\\]{top:123px}",
   "top-[-123px]": ".top-\\[-123px\\]{top:-123px}",
+  "text-[6px]": ".text-\\[6px\\]{font-size:6px}",
+  "text-[1.5em/1.8em]": ".text-\\[1\\.5em\\/1\\.8em\\]{font-size:1.5em/1.8em}",
+  "text-[calc(1vw+1vh+.5vmin)]": ".text-\\[calc\\(1vw\\+1vh\\+\\.5vmin\\)\\]{font-size:calc(1vw+1vh+.5vmin)}",
+  "text-[#1da1f2]": ".text-\\[\\#1da1f2\\]{--tw-text-opacity:1;color:#1da1f2;color:rgba(29,161,242,var(--tw-text-opacity))}",
   "grid-cols-[minmax(100px,max-content)repeat(auto-fill,200px)20%]": ".grid-cols-\\[minmax\\(100px\\,max-content\\)repeat\\(auto-fill\\,200px\\)20\\%\\]{grid-template-columns:minmax(100px,max-content)repeat(auto-fill,200px)20%}",
   "grid-cols-[repeat(auto-fit,minmax(150px,1fr))]": ".grid-cols-\\[repeat\\(auto-fit\\,minmax\\(150px\\,1fr\\)\\)\\]{grid-template-columns:repeat(auto-fit,minmax(150px,1fr))}",
   "grid-rows-auto-1fr-auto": ".grid-rows-auto-1fr-auto{grid-template-rows:auto-1fr-auto}",
   "w-[clamp(23ch,50%,46ch)]": ".w-\\[clamp\\(23ch\\,50\\%\\,46ch\\)\\]{width:clamp(23ch,50%,46ch)}",
   "bg-[#1da1f2]": ".bg-\\[\\#1da1f2\\]{--tw-bg-opacity:1;background-color:#1da1f2;background-color:rgba(29,161,242,var(--tw-bg-opacity))}",
   "translate-x-[-650px]": ".translate-x-\\[-650px\\]{--tw-translate-x:-650px;transform:translateX(-650px);transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}",
-  "text-[#1da1f2]": ".text-\\[\\#1da1f2\\]{--tw-text-opacity:1;color:#1da1f2;color:rgba(29,161,242,var(--tw-text-opacity))}"
+  "ring-[7px]": [
+    "*{--tw-ring-inset:var(--tw-empty,/*!*/ /*!*/);--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-color:rgba(59,130,246,var(--tw-ring-opacity,0.5));--tw-ring-offset-shadow:0 0 transparent;--tw-ring-shadow:0 0 transparent}",
+    ".ring-\\[7px\\]{--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(7px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow,0 0 transparent)}"
+  ],
+  "ring-[#1da1f2]": ".ring-\\[\\#1da1f2\\]{--tw-ring-opacity:1;--tw-ring-color:rgba(29,161,242,var(--tw-ring-opacity))}",
+  "ring-offset-[7px]": ".ring-offset-\\[7px\\]{--tw-ring-offset-width:7px}",
+  "ring-offset-[#1da1f2]": ".ring-offset-\\[\\#1da1f2\\]{--tw-ring-offset-color:#1da1f2}",
+  "rounded-[33%]": ".rounded-\\[33\\%\\]{border-radius:33%}",
+  "transition-[font-size,color,width]": ".transition-\\[font-size\\,color\\,width\\]{transition-property:font-size,color,width;transition-timing-function:cubic-bezier(0.4,0,0.2,1);transition-duration:150ms}",
+  "rotate-[0.5turn]": ".rotate-\\[0\\.5turn\\]{--tw-rotate:0.5turn;transform:rotate(0.5turn);transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}",
+  "scale-[2]": ".scale-\\[2\\]{--tw-scale-x:2;--tw-scale-y:2;transform:scale(2);transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}",
+  "scale-x-[1.15]": ".scale-x-\\[1\\.15\\]{--tw-scale-x:1.15;transform:scaleX(1.15);transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}",
+  "skew-[30deg]": ".skew-\\[30deg\\]{--tw-skew-x:30deg;--tw-skew-y:30deg;transform:skew(30deg);transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}",
+  "skew-x-[1.07rad]": ".skew-x-\\[1\\.07rad\\]{--tw-skew-x:1.07rad;transform:skewX(1.07rad);transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}",
+  "translate-[3in]": ".translate-\\[3in\\]{--tw-translate-x:3in;--tw-translate-y:3in;transform:translate(3in);transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}",
+  "translate-y-[2px]": ".translate-y-\\[2px\\]{--tw-translate-y:2px;transform:translateY(2px);transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}",
+  "bg-[#0f0] bg-[#ff0000] bg-[#0000ffcc]": [
+    ".bg-\\[\\#0f0\\]{--tw-bg-opacity:1;background-color:#0f0;background-color:rgba(0,255,0,var(--tw-bg-opacity))}",
+    ".bg-\\[\\#ff0000\\]{--tw-bg-opacity:1;background-color:#ff0000;background-color:rgba(255,0,0,var(--tw-bg-opacity))}",
+    ".bg-\\[\\#0000ffcc\\]{background-color:#0000ffcc}"
+  ],
+  "bg-[rgb(123,123,123)] bg-[rgba(123,123,123,var(--tw-bg-opacity,1))]": [
+    ".bg-\\[rgb\\(123\\,123\\,123\\)\\]{background-color:rgb(123,123,123)}",
+    ".bg-\\[rgba\\(123\\,123\\,123\\,var\\(--tw-bg-opacity\\,1\\)\\)\\]{background-color:rgba(123,123,123,var(--tw-bg-opacity,1))}"
+  ],
+  "bg-[hsl(0,100%,50%)] bg-[hsla(0,100%,50%,0.3)]": [
+    ".bg-\\[hsl\\(0\\,100\\%\\,50\\%\\)\\]{background-color:hsl(0,100%,50%)}",
+    ".bg-\\[hsla\\(0\\,100\\%\\,50\\%\\,0\\.3\\)\\]{background-color:hsla(0,100%,50%,0.3)}"
+  ],
+  "bg-opacity-[0.11]": ".bg-opacity-\\[0\\.11\\]{--tw-bg-opacity:0.11}",
+  "border-[#f00]": ".border-\\[\\#f00\\]{--tw-border-opacity:1;border-color:#f00;border-color:rgba(255,0,0,var(--tw-border-opacity))}",
+  "border-[2.5px]": ".border-\\[2\\.5px\\]{border-width:2.5px}",
+  "from-[#0f0] to-[#ff0000] via-[#0000ffcc]": [
+    ".from-\\[\\#0f0\\]{--tw-gradient-from:#0f0;--tw-gradient-stops:var(--tw-gradient-from),var(--tw-gradient-to,rgba(0,255,0,0))}",
+    ".to-\\[\\#ff0000\\]{--tw-gradient-to:#ff0000}",
+    ".via-\\[\\#0000ffcc\\]{--tw-gradient-stops:var(--tw-gradient-from),#0000ffcc,var(--tw-gradient-to,#0000ffcc)}"
+  ],
+  "from-[rgb(123,123,123)] to-[rgba(123,123,123,.5)]": [
+    ".from-\\[rgb\\(123\\,123\\,123\\)\\]{--tw-gradient-from:rgb(123,123,123);--tw-gradient-stops:var(--tw-gradient-from),var(--tw-gradient-to,transparent)}",
+    ".to-\\[rgba\\(123\\,123\\,123\\,\\.5\\)\\]{--tw-gradient-to:rgba(123,123,123,.5)}"
+  ],
+  "from-[hsl(0,100%,50%)] to-[hsla(0,100%,50%,0.3)]": [
+    ".from-\\[hsl\\(0\\,100\\%\\,50\\%\\)\\]{--tw-gradient-from:hsl(0,100%,50%);--tw-gradient-stops:var(--tw-gradient-from),var(--tw-gradient-to,transparent)}",
+    ".to-\\[hsla\\(0\\,100\\%\\,50\\%\\,0\\.3\\)\\]{--tw-gradient-to:hsla(0,100%,50%,0.3)}"
+  ],
+  "w-[3.23rem]": ".w-\\[3\\.23rem\\]{width:3.23rem}",
+  "w-[calc(100%+1rem)]": ".w-\\[calc\\(100\\%\\+1rem\\)\\]{width:calc(100%+1rem)}",
+  "space-x-[20cm]": ".space-x-\\[20cm\\]>:not([hidden])~:not([hidden]){--tw-space-x-reverse:0;margin-right:calc(20cm * var(--tw-space-x-reverse));margin-left:20cm;margin-left:calc(20cm * calc(1 - var(--tw-space-x-reverse)))}",
+  "space-x-[calc(20%-1cm)]": ".space-x-\\[calc\\(20\\%-1cm\\)\\]>:not([hidden])~:not([hidden]){--tw-space-x-reverse:0;margin-right:calc(calc(20%-1cm) * var(--tw-space-x-reverse));margin-left:calc(20%-1cm);margin-left:calc(calc(20%-1cm) * calc(1 - var(--tw-space-x-reverse)))}",
+  "grid-cols-[200px,repeat(auto-fill,minmax(15%,100px)),300px]": ".grid-cols-\\[200px\\,repeat\\(auto-fill\\,minmax\\(15\\%\\,100px\\)\\)\\,300px\\]{grid-template-columns:200px,repeat(auto-fill,minmax(15%,100px)),300px}",
+  "rotate-[23deg] rotate-[2.3rad] rotate-[401grad] rotate-[1.5turn]": [
+    ".rotate-\\[23deg\\]{--tw-rotate:23deg;transform:rotate(23deg);transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}",
+    ".rotate-\\[2\\.3rad\\]{--tw-rotate:2.3rad;transform:rotate(2.3rad);transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}",
+    ".rotate-\\[401grad\\]{--tw-rotate:401grad;transform:rotate(401grad);transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}",
+    ".rotate-\\[1\\.5turn\\]{--tw-rotate:1.5turn;transform:rotate(1.5turn);transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}"
+  ],
+  "duration-[2s]": ".duration-\\[2s\\]{transition-duration:2s}",
+  "text-[2.23rem]": ".text-\\[2\\.23rem\\]{font-size:2.23rem}"
 }

--- a/src/__tests__/api.json
+++ b/src/__tests__/api.json
@@ -794,5 +794,14 @@
   "invalid:not-focus:border-red-500": ".invalid\\:not-focus\\:border-red-500:invalid:not(:focus){--tw-border-opacity:1;border-color:#ef4444;border-color:rgba(239,68,68,var(--tw-border-opacity))}",
   "not-disabled:focus:font-bold": ".not-disabled\\:focus\\:font-bold:not(:disabled):focus{font-weight:700}",
   "not-logged-in:hidden": "body:not(.logged-in) .not-logged-in\\:hidden{display:none}",
-  "not-last-child:mb-5": ".not-last-child\\:mb-5:not(:last-child){margin-bottom:1.25rem}"
+  "not-last-child:mb-5": ".not-last-child\\:mb-5:not(:last-child){margin-bottom:1.25rem}",
+  "top-[123px]": ".top-\\[123px\\]{top:123px}",
+  "top-[-123px]": ".top-\\[-123px\\]{top:-123px}",
+  "grid-cols-[minmax(100px,max-content)repeat(auto-fill,200px)20%]": ".grid-cols-\\[minmax\\(100px\\,max-content\\)repeat\\(auto-fill\\,200px\\)20\\%\\]{grid-template-columns:minmax(100px,max-content)repeat(auto-fill,200px)20%}",
+  "grid-cols-[repeat(auto-fit,minmax(150px,1fr))]": ".grid-cols-\\[repeat\\(auto-fit\\,minmax\\(150px\\,1fr\\)\\)\\]{grid-template-columns:repeat(auto-fit,minmax(150px,1fr))}",
+  "grid-rows-auto-1fr-auto": ".grid-rows-auto-1fr-auto{grid-template-rows:auto-1fr-auto}",
+  "w-[clamp(23ch,50%,46ch)]": ".w-\\[clamp\\(23ch\\,50\\%\\,46ch\\)\\]{width:clamp(23ch,50%,46ch)}",
+  "bg-[#1da1f2]": ".bg-\\[\\#1da1f2\\]{--tw-bg-opacity:1;background-color:#1da1f2;background-color:rgba(29,161,242,var(--tw-bg-opacity))}",
+  "translate-x-[-650px]": ".translate-x-\\[-650px\\]{--tw-translate-x:-650px;transform:translateX(-650px);transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}",
+  "text-[#1da1f2]": ".text-\\[\\#1da1f2\\]{--tw-text-opacity:1;color:#1da1f2;color:rgba(29,161,242,var(--tw-text-opacity))}"
 }

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -972,4 +972,17 @@ test('using @import with array', ({ tw, sheet }) => {
   ])
 })
 
+test('using interpolated arbitrary value', ({ tw, sheet }) => {
+  assert.is(tw`py-[${0}px] my-[${5}px]`, 'py-[0px] my-[5px]')
+  assert.equal(sheet.target, [
+    '.py-\\[0px\\]{padding-bottom:0px;padding-top:0px}',
+    '.my-\\[5px\\]{margin-bottom:5px;margin-top:5px}',
+  ])
+
+  sheet.reset()
+
+  assert.is(tw`p-${'[3px]'}`, 'p-[3px]')
+  assert.equal(sheet.target, ['.p-\\[3px\\]{padding:3px}'])
+})
+
 test.run()

--- a/src/internal/util.ts
+++ b/src/internal/util.ts
@@ -80,20 +80,13 @@ export const escape =
   (typeof CSS !== 'undefined' && CSS.escape) ||
   // Simplified: escaping only special characters
   // Needed for NodeJS and Edge <79 (https://caniuse.com/mdn-api_css_escape)
-  ((className: string): string => {
-    const firstCodeUnit = className.charCodeAt(0)
-    let firstChar = ''
-
-    // If the character is the first character and is in the range [0-9] (2xl, ...)
-    if (firstCodeUnit >= 0x0030 && firstCodeUnit <= 0x0039) {
+  ((className: string): string =>
+    className
+      // Simplifed escape testing only for chars that we know happen to be in tailwind directives
+      .replace(/[!"'`*+.,;:\\/<=>?@#$%&^|~()[\]{}]/g, '\\$&')
+      // If the character is the first character and is in the range [0-9] (2xl, ...)
       // https://drafts.csswg.org/cssom/#escape-a-character-as-code-point
-      firstChar = '\\' + firstCodeUnit.toString(16) + ' '
-      className = tail(className)
-    }
-
-    // Simplifed escape testing only for chars that we know happen to be in tailwind directives
-    return firstChar + className.replace(/[!.,;/+*:#()[\]%"']/g, '\\$&')
-  })
+      .replace(/^\d/, '\\3$& '))
 
 export const buildMediaQuery = (screen: ThemeScreen): string => {
   if (!Array.isArray(screen)) {

--- a/src/internal/util.ts
+++ b/src/internal/util.ts
@@ -92,7 +92,7 @@ export const escape =
     }
 
     // Simplifed escape testing only for chars that we know happen to be in tailwind directives
-    return firstChar + className.replace(/[!./:#]/g, '\\$&')
+    return firstChar + className.replace(/[!.,;/+*:#()[\]%"']/g, '\\$&')
   })
 
 export const buildMediaQuery = (screen: ThemeScreen): string => {

--- a/src/twind/configure.ts
+++ b/src/twind/configure.ts
@@ -22,7 +22,7 @@ import { silent, strict, warn } from './modes'
 import { autoprefix, noprefix } from './prefix'
 import { makeThemeResolver } from './theme'
 
-import { cyrb32, identity, join, tail, merge, evalThunk, ensureMaxSize } from '../internal/util'
+import { cyrb32, identity, tail, merge, evalThunk, ensureMaxSize, includes } from '../internal/util'
 
 import { parse } from './parse'
 import { translate as makeTranslate } from './translate'
@@ -80,36 +80,27 @@ export const configure = (
   let translateDepth = 0
   const lastTranslations: (CSSRules | string | Falsy)[] = []
 
-  const handleDynamic = (key: string | string[]): string | undefined => {
-    const value = Array.isArray(key) ? join(key) : key
-    return value[0] == '[' || value[value.length - 1] == ']' ? value.slice(1, -1) : undefined
-  }
-
   // The context that is passed to functions to access the theme, ...
   const context: Context = {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     tw: (...tokens: unknown[]) => process(tokens),
 
     theme: ((section: keyof Theme, key?: string | string[], defaultValue?: unknown): unknown => {
-      // Empty key use the standard tailwind default key
-      if (key != null && !key.length) {
-        key = 'DEFAULT'
-      }
-
       const value =
-        (key && defaultValue != '' && handleDynamic(key)) ||
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (theme(section, key as string, defaultValue as any) ??
-          // If no theme value is found, notify 'mode', it may be able to resolve a value
-          mode.unknown(
-            section,
-            key == null || Array.isArray(key) ? key : key.split('.'),
-            defaultValue != null,
-            context,
-          ))
+        theme(section, key as string, defaultValue as any) ??
+        // If no theme value is found, notify 'mode', it may be able to resolve a value
+        mode.unknown(
+          section,
+          key == null || Array.isArray(key) ? key : key.split('.'),
+          defaultValue != null,
+          context,
+        )
 
       // Add negate to theme value using calc to support complex values
-      return activeRule.n && value && typeof value == 'string' ? `calc(${value} * -1)` : value
+      return activeRule.n && value && includes('rg', (typeof value)[5])
+        ? `calc(${value} * -1)`
+        : value
     }) as ThemeResolver,
 
     tag: (value) => (hash ? hash(value) : value),

--- a/src/twind/parse.ts
+++ b/src/twind/parse.ts
@@ -73,7 +73,7 @@ const saveRule = (buffer: string): '' => {
     buffer = tail(buffer)
   }
 
-  const important = buffer[buffer.length - 1] == '!'
+  const important = buffer.slice(-1) == '!'
 
   if (important) {
     buffer = buffer.slice(0, -1)
@@ -219,7 +219,10 @@ const buildStatics = (strings: TemplateStringsArray): Static[] => {
     let buffer = ''
 
     statics = strings.map((token, index) => {
-      if (slowModeIndex !== slowModeIndex && includes(':-(', (strings[index + 1] || '')[0])) {
+      if (
+        slowModeIndex !== slowModeIndex &&
+        (token.slice(-1) == '[' || includes(':-(', (strings[index + 1] || '')[0]))
+      ) {
         // If the the string after the upcoming interpolation
         // would start a grouping we switch to slow mode now
         slowModeIndex = index
@@ -235,8 +238,8 @@ const buildStatics = (strings: TemplateStringsArray): Static[] => {
 
           buffer += token
 
-          // Join consecutive strings
-          if (typeof interpolation == 'string') {
+          // Join consecutive strings and numbers
+          if (includes('rg', (typeof interpolation)[5])) {
             buffer += interpolation
           } else if (interpolation) {
             parseString(buffer)

--- a/src/twind/parse.ts
+++ b/src/twind/parse.ts
@@ -87,11 +87,16 @@ const saveRule = (buffer: string): '' => {
 }
 
 const parseString = (token: string, isVariant?: boolean): void => {
-  let char: string
   let buffer = ''
 
-  for (let position = 0; position < token.length; ) {
-    switch ((char = token[position++])) {
+  for (let char: string, dynamic = false, position = 0; (char = token[position++]); ) {
+    if (dynamic || char == '[') {
+      buffer += char
+      dynamic = char != ']'
+      continue
+    }
+
+    switch (char) {
       case ':':
         // Check if this is an pseudo element "after::"
         buffer =

--- a/src/twind/plugins.ts
+++ b/src/twind/plugins.ts
@@ -92,14 +92,11 @@ const asRGBA = <T extends string | undefined>(
   opacityProperty: string,
   opacityDefault?: string,
 ): T | string => {
-  if (color && color[0] == '#') {
-    return `rgba(${parseColorComponent(
-      color.substr(1, (_ = (color.length - 1) / 3)),
-      ($ = [17, 1, 0.062272][_ - 1]),
-    )},${parseColorComponent(color.substr(1 + _, _), $)},${parseColorComponent(
-      color.substr(1 + 2 * _, _),
+  if (color && color[0] == '#' && (_ = (color.length - 1) / 3) && ($ = [17, 1, 0.062272][_ - 1])) {
+    return `rgba(${parseColorComponent(color.substr(1, _), $)},${parseColorComponent(
+      color.substr(1 + _, _),
       $,
-    )},${
+    )},${parseColorComponent(color.substr(1 + 2 * _, _), $)},${
       opacityProperty
         ? `var(--tw-${opacityProperty}${opacityDefault ? ',' + opacityDefault : ''})`
         : opacityDefault || 1

--- a/src/twind/theme.ts
+++ b/src/twind/theme.ts
@@ -832,6 +832,11 @@ const resolveContext: ThemeSectionResolverContext = {
       }, {} as Record<string, string | undefined>),
 }
 
+const handleArbitraryValues = (section: keyof Theme, key: string): string | false =>
+  (key = (key[0] == '[' && key.slice(-1) == ']' && key.slice(1, -1)) as string) &&
+  includes(section, 'olor') == (key[0] == '#' || /^(?:#|(?:hsl|rgb)a?\()/.test(key)) &&
+  key
+
 export const makeThemeResolver = (config?: ThemeConfiguration): ThemeResolver => {
   const cache = new Map<keyof Theme, Record<string, unknown>>()
 
@@ -871,7 +876,9 @@ export const makeThemeResolver = (config?: ThemeConfiguration): ThemeResolver =>
     }
 
     if (key != null) {
-      const value: unknown = base[(Array.isArray(key) ? join(key) : (key as string)) || 'DEFAULT']
+      key = (Array.isArray(key) ? join(key) : (key as string)) || 'DEFAULT'
+
+      const value: unknown = handleArbitraryValues(section, key as string) || base[key as string]
 
       return value == null
         ? defaultValue

--- a/src/twind/translate.ts
+++ b/src/twind/translate.ts
@@ -22,7 +22,7 @@ export const translate = (
     return rule.d(context)
   }
 
-  const parameters = rule.d.split('-')
+  const parameters = rule.d.split(/-(?![^[]*])/g)
 
   // Bail early for already hashed class names
   // Only if there are no variants and no negation

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,11 +452,6 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
-buffer-from@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
-  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
-
 buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
@@ -827,13 +822,13 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-distilt@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.npmjs.org/distilt/-/distilt-0.10.1.tgz#7603f8f3b64c24e7ed66a696ee0ec85dbb2d4dc4"
-  integrity sha512-JZSjKlpXMDBunrwlpDZW3+L+UlnjaSP1egOfEPix7anPXG24Mq3d9SRghpQkoZs8jeCq76Gnp3/VL2uM1NXtSA==
+distilt@^0.10.2:
+  version "0.10.2"
+  resolved "https://registry.npmjs.org/distilt/-/distilt-0.10.2.tgz#40e3c6bb45c9495e44857e0c37ea120380926c05"
+  integrity sha512-m+d3aWg6OnpnzWttFsEaXakcauXFw5tQhxf3Hzh0JDMKtfqRBHezKbf/3+gucLz39583yA6EiDJYmUMC4b98AA==
   dependencies:
     es-module-lexer "^0.3.26"
-    esbuild "^0.8.28"
+    esbuild "^0.9.3"
     execa "^5.0.0"
     find-up "^5.0.0"
     globby "^11.0.1"
@@ -959,20 +954,22 @@ es-module-lexer@^0.3.26:
   resolved "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.3.26.tgz#7b507044e97d5b03b01d4392c74ffeb9c177a83b"
   integrity sha512-Va0Q/xqtrss45hWzP8CZJwzGSZJjDM5/MJRE3IXXnUCcVLElR9BRaE9F62BopysASyc4nM3uwhSW7FFB9nlWAA==
 
-esbuild-register@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/esbuild-register/-/esbuild-register-2.0.0.tgz#579a6eff4e5713a318602b4d305bcb6f8c5b08f9"
-  integrity sha512-98i1+7OnCURCbKaWw5wnY05e4v7uknFEER7LtVxi/lCs8U+sl6/LnITvfeoDLrsqxlA3O6BjxK8QqsirfYULfA==
+esbuild-register@~2.2.1:
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/esbuild-register/-/esbuild-register-2.2.1.tgz#ba7fe04221d4789a33fc1956c68663196e90632c"
+  integrity sha512-kNFpH+W7eY1MN2v0qS7zjlV7zWKsWjX9Di0luPcuPdC6Q/8Xm2tWjxSVaNBbYRjOgQm5q+cciCvszICJYzgmOA==
   dependencies:
-    joycon "^2.2.5"
-    pirates "^4.0.1"
-    source-map-support "^0.5.19"
-    strip-json-comments "^3.1.1"
+    jsonc-parser "^3.0.0"
 
-esbuild@^0.8.28, esbuild@^0.8.31, esbuild@^0.8.7:
+esbuild@^0.8.7:
   version "0.8.44"
   resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.8.44.tgz#2a74f48fe20579081c9d8fe99be6fb8d2848c887"
   integrity sha512-m9yyBZMgWuAB7e7tA2g9L4PovoLa5Xb73+Yg9uBBR2w3Fe4P9/nxqj/HLrw1k/rjdjF1eX1kNJRytboqOtRCCQ==
+
+esbuild@^0.9.3:
+  version "0.9.4"
+  resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.9.4.tgz#4480ffc4c1e5d5bb25958f889b5de0279bfb2d6f"
+  integrity sha512-bF6laCiYE5+iAfZsX+v6Lwvi5QbvKN3tThxDIR2WLyLYzTzNn0ijdpqkvTVsafmRZjic2Nq1nkSf5RSWySDTjA==
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -1759,11 +1756,6 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-joycon@^2.2.5:
-  version "2.2.5"
-  resolved "https://registry.npmjs.org/joycon/-/joycon-2.2.5.tgz#8d4cf4cbb2544d7b7583c216fcdfec19f6be1615"
-  integrity sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ==
-
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -1850,6 +1842,11 @@ json5@^1.0.1:
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
+
+jsonc-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz#abdd785701c7e7eaca8a9ec8cf070ca51a745a22"
+  integrity sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==
 
 jsonfile@^6.0.1:
   version "6.1.0"
@@ -2110,11 +2107,6 @@ node-emoji@^1.8.1:
   dependencies:
     lodash.toarray "^4.4.0"
 
-node-modules-regexp@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
-  integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
-
 normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -2337,13 +2329,6 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
-
-pirates@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
-  integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
-  dependencies:
-    node-modules-regexp "^1.0.0"
 
 pkg-dir@^5.0.0:
   version "5.0.0"
@@ -2863,15 +2848,7 @@ snowpack@^3.0.11:
   optionalDependencies:
     fsevents "^2.2.0"
 
-source-map-support@^0.5.19:
-  version "0.5.19"
-  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
-  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==


### PR DESCRIPTION
This PR adds the new tailwindcss square bracket notation like `top-[-113px]`. Works with variants too, like `md:top-[-113px]`.

This works in places where a theme value would be used. So almost everywhere.

I would like to add a config option to disable this feature. But I'm unsure of the name. Any pointers?

Which one do you prefer: arbitraryValues or dynamicValues?

---

Here are some examples: _Not everyone works right now – working on colors vs other value_

```
bg-[#0f0]
bg-[#ff0000]
bg-[#0000ffcc]
bg-[hsl(0,100%,50%)]
bg-[hsla(0,100%,50%,0.3)]
bg-[rgb(123,123,123)]
bg-[rgba(123,123,123,var(--tw-bg-opacity))]
bg-opacity-[0.11]
border-[#f00]
border-[2.5px]
duration-[2s]
grid-cols-[200px,repeat(auto-fill,minmax(15%,100px)),300px]
grid-cols-[minmax(100px,max-content)repeat(auto-fill,200px)20%]
grid-cols-[repeat(auto-fit,minmax(150px,1fr))]
flex-[30%]
ring-[#1da1f2]
ring-[7px]
ring-offset-[#1da1f2]
ring-offset-[7px]
rotate-[0.5turn]
rotate-[23deg] rotate-[2.3rad] rotate-[401grad] rotate-[1.5turn]
rounded-[33%]
scale-[2]
scale-x-[1.15]
skew-[30deg]
skew-x-[1.07rad]
space-x-[20cm]
space-x-[calc(20%-1cm)]
text-[#1da1f2]
text-[2.23rem]
text-[6px]
text-[calc(1vw+1vh+.5vmin)]
top-[-123px]
top-[123px]
transition-[font-size,color,width]
translate-[3in]
translate-y-[2px]
w-[3.23rem]
w-[calc(100%+1rem)]
w-[clamp(23ch,50%,46ch)]
```

/cc @tw-in-js/contributors 
