### PR TITLE
fix: support `not-` prefix for pseudo classes

### DIFF
--- a/src/__tests__/api.json
+++ b/src/__tests__/api.json
@@ -375,6 +375,7 @@
   "grid-rows-1": ".grid-rows-1{grid-template-rows:repeat(1,minmax(0,1fr))}",
   "grid-rows-none": ".grid-rows-none{grid-template-rows:none}",
   "grid-rows-layout": ".grid-rows-layout{grid-template-rows:200px minmax(900px, 1fr) 100px}",
+  "grid-rows-auto-1fr-auto": ".grid-rows-auto-1fr-auto{grid-template-rows:auto-1fr-auto}",
   "grid-flow-row": ".grid-flow-row{grid-auto-flow:row}",
   "grid-flow-col": ".grid-flow-col{grid-auto-flow:column}",
   "auto-rows-auto": ".auto-rows-auto{grid-auto-rows:auto}",
@@ -788,5 +789,10 @@
   "siblings:underline": ".siblings\\:underline~*{text-decoration:underline}",
   "sibling:underline": ".sibling\\:underline+*{text-decoration:underline}",
   "text-center!": ".text-center\\!{text-align:center !important}",
-  "override:text-center": ".override\\:text-center.override\\:text-center{text-align:center}"
+  "override:text-center": ".override\\:text-center.override\\:text-center{text-align:center}",
+  "not-focus:invalid:border-red-500": ".not-focus\\:invalid\\:border-red-500:not(:focus):invalid{--tw-border-opacity:1;border-color:#ef4444;border-color:rgba(239,68,68,var(--tw-border-opacity))}",
+  "invalid:not-focus:border-red-500": ".invalid\\:not-focus\\:border-red-500:invalid:not(:focus){--tw-border-opacity:1;border-color:#ef4444;border-color:rgba(239,68,68,var(--tw-border-opacity))}",
+  "not-disabled:focus:font-bold": ".not-disabled\\:focus\\:font-bold:not(:disabled):focus{font-weight:700}",
+  "not-logged-in:hidden": "body:not(.logged-in) .not-logged-in\\:hidden{display:none}",
+  "not-last-child:mb-5": ".not-last-child\\:mb-5:not(:last-child){margin-bottom:1.25rem}"
 }

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -22,6 +22,9 @@ test.before((context) => {
     mode: strict,
     preflight: false,
     prefix: false,
+    variants: {
+      'not-logged-in': 'body:not(.logged-in) &',
+    },
     theme: {
       extend: {
         screens: {

--- a/src/twind/decorate.ts
+++ b/src/twind/decorate.ts
@@ -5,6 +5,7 @@ import { tail, escape, buildMediaQuery } from '../internal/util'
 let _: RegExpExecArray | null | readonly ThemeScreenValue[] | string
 
 export const GROUP_RE = /^:(group(?:(?!-focus).+?)*)-(.+)$/
+export const NOT_PREFIX_RE = /^(:not)-(.+)/
 
 // Wraps a CSS rule object with variant at-rules and pseudo classes
 // { '.selector': {...} }
@@ -36,7 +37,9 @@ export const decorate = (
 
     // Check other well known variants
     // and fallback to pseudo class or element
-    return { [variants[tail(variant)] || '&' + variant]: translation }
+    return {
+      [variants[tail(variant)] || '&' + variant.replace(NOT_PREFIX_RE, '$1(:$2)')]: translation,
+    }
   }
 
   // Apply variants depth-first

--- a/src/twind/presedence.ts
+++ b/src/twind/presedence.ts
@@ -71,7 +71,7 @@ Ensure shorthand properties are inserted before longhand properties; eg longhand
 import type { ThemeResolver, ThemeScreen } from '../types'
 
 import { tail, includes, buildMediaQuery } from '../internal/util'
-import { GROUP_RE } from './decorate'
+import { GROUP_RE, NOT_PREFIX_RE } from './decorate'
 
 // Shared variables
 let _: string | RegExpExecArray | null | number | ThemeScreen
@@ -182,7 +182,7 @@ export const makeVariantPresedenceCalculator = (
     variant == ':dark'
     ? 1 << 30
     : // 4: precedence of other at-rules
-    (_ = variants[variant] || variant)[0] == '@'
+    (_ = variants[variant] || variant.replace(NOT_PREFIX_RE, ':$2'))[0] == '@'
     ? atRulePresedence(_)
     : // 17: pseudo and group variants
       pseudoPrecedence(variant))


### PR DESCRIPTION
This PR allows to negate [pseudo class](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes) variants using `not-`prefix which will be expanded to ` :not(...)`.

Examples:

| Class name                         | Selector                                                    |
| ---------------------------------- | ----------------------------------------------------------- |
| `not-focus:invalid:border-red-500` | `.not-focus\\:invalid\\:border-red-500:not(:focus):invalid` |
| `invalid:not-focus:border-red-500` | `.invalid\\:not-focus\\:border-red-500:invalid:not(:focus)` |
| `not-disabled:focus:font-bold`     | `.not-disabled\\:focus\\:font-bold:not(:disabled):focus`    |
| `not-last-child:mb-5`              | `.not-last-child\\:mb-5:not(:last-child)`                   |

Core and user defined variants **are not** handled and stay as is.

Example:

```js
setup({
  variants: {
    'not-logged-in': 'body:not(.logged-in) &',
  },
})

tw`not-logged-in:hidden`
// => `body:not(.logged-in) .not-logged-in\\:hidden`
```

