### PR TITLE
support important modifier as prefix and for groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,35 +51,45 @@
       "path": "dist/colors/colors.js",
       "brotli": true,
       "limit": "1kb",
-      "ignore": ["twind"]
+      "ignore": [
+        "twind"
+      ]
     },
     {
       "name": "twind/css",
       "path": "dist/css/css.js",
       "brotli": true,
       "limit": "1kb",
-      "ignore": ["twind"]
+      "ignore": [
+        "twind"
+      ]
     },
     {
       "name": "twind/observe",
       "path": "dist/observe/observe.js",
       "brotli": true,
       "limit": "0.7kb",
-      "ignore": ["twind"]
+      "ignore": [
+        "twind"
+      ]
     },
     {
       "name": "twind/shim",
       "path": "dist/shim/shim.js",
       "brotli": true,
       "limit": "0.3kb",
-      "ignore": ["twind"]
+      "ignore": [
+        "twind"
+      ]
     },
     {
       "name": "twind/style",
       "path": "dist/style/style.js",
       "brotli": true,
       "limit": "0.8kb",
-      "ignore": ["twind"]
+      "ignore": [
+        "twind"
+      ]
     }
   ],
   "// These are ONLY bundled (eg included) in the umd builds": "",

--- a/src/__tests__/api.json
+++ b/src/__tests__/api.json
@@ -788,7 +788,41 @@
   "children:underline": ".children\\:underline>*{text-decoration:underline}",
   "siblings:underline": ".siblings\\:underline~*{text-decoration:underline}",
   "sibling:underline": ".sibling\\:underline+*{text-decoration:underline}",
-  "text-center!": ".text-center\\!{text-align:center !important}",
+  "!text-center": ".\\!text-center{text-align:center !important}",
+  "text-center!": ["!text-center", [".\\!text-center{text-align:center !important}"]],
+  "!(text-center font-bold)": [
+    "!text-center !font-bold",
+    [".\\!text-center{text-align:center !important}", ".\\!font-bold{font-weight:700 !important}"]
+  ],
+  "hover:!(text-center font-bold)": [
+    "hover:!text-center hover:!font-bold",
+    [
+      ".hover\\:\\!text-center:hover{text-align:center !important}",
+      ".hover\\:\\!font-bold:hover{font-weight:700 !important}"
+    ]
+  ],
+  "hover:!(text-center focus:font-bold)": [
+    "hover:!text-center hover:focus:!font-bold",
+    [
+      ".hover\\:\\!text-center:hover{text-align:center !important}",
+      ".hover\\:focus\\:\\!font-bold:hover:focus{font-weight:700 !important}"
+    ]
+  ],
+  "!hover:(text-center focus:font-bold)": [
+    "hover:!text-center hover:focus:!font-bold",
+    [
+      ".hover\\:\\!text-center:hover{text-align:center !important}",
+      ".hover\\:focus\\:\\!font-bold:hover:focus{font-weight:700 !important}"
+    ]
+  ],
+  "!text(xl underline) md:!m(-8)": [
+    "!text-xl !text-underline md:!-m-8",
+    [
+      ".\\!text-xl{font-size:1.25rem !important;line-height:1.75rem !important}",
+      ".\\!text-underline{text-decoration:underline !important}",
+      "@media (min-width:768px){.md\\:\\!-m-8{margin:calc(2rem * -1) !important}}"
+    ]
+  ],
   "override:text-center": ".override\\:text-center.override\\:text-center{text-align:center}",
   "not-focus:invalid:border-red-500": ".not-focus\\:invalid\\:border-red-500:not(:focus):invalid{--tw-border-opacity:1;border-color:#ef4444;border-color:rgba(239,68,68,var(--tw-border-opacity))}",
   "invalid:not-focus:border-red-500": ".invalid\\:not-focus\\:border-red-500:invalid:not(:focus){--tw-border-opacity:1;border-color:#ef4444;border-color:rgba(239,68,68,var(--tw-border-opacity))}",

--- a/src/__tests__/api.json
+++ b/src/__tests__/api.json
@@ -815,6 +815,14 @@
       ".hover\\:focus\\:\\!font-bold:hover:focus{font-weight:700 !important}"
     ]
   ],
+  "text!(xl underline)": [
+    "!text-xl !text-underline",
+    [
+      ".\\!text-xl{font-size:1.25rem !important;line-height:1.75rem !important}",
+      ".\\!text-underline{text-decoration:underline !important}"
+    ]
+  ],
+  "!-m-8": ".\\!-m-8{margin:calc(2rem * -1) !important}",
   "!text(xl underline) md:!m(-8)": [
     "!text-xl !text-underline md:!-m-8",
     [

--- a/src/__tests__/prefix.test.ts
+++ b/src/__tests__/prefix.test.ts
@@ -44,13 +44,13 @@ test('add prefix', ({ sheet, instance }) => {
 
 test('add prefix with important', ({ sheet, instance }) => {
   assert.is(
-    instance.tw('sticky! scroll-snap-x! appearance-menulist-button!'),
-    'sticky! scroll-snap-x! appearance-menulist-button!',
+    instance.tw('sticky! !scroll-snap-x appearance-menulist-button!'),
+    '!sticky !scroll-snap-x !appearance-menulist-button',
   )
   assert.equal(sheet.target, [
-    '.sticky\\!{position:-webkit-sticky !important;position:sticky !important}',
-    '.appearance-menulist-button\\!{-webkit-appearance:menulist-button !important;-moz-appearance:menulist-button !important;appearance:menulist-button !important}',
-    '.scroll-snap-x\\!{scroll-snap-type:x !important}',
+    '.\\!sticky{position:-webkit-sticky !important;position:sticky !important}',
+    '.\\!appearance-menulist-button{-webkit-appearance:menulist-button !important;-moz-appearance:menulist-button !important;appearance:menulist-button !important}',
+    '.\\!scroll-snap-x{scroll-snap-type:x !important}',
   ])
 })
 

--- a/src/twind/configure.ts
+++ b/src/twind/configure.ts
@@ -59,7 +59,7 @@ const stringifyVariant = (selector: string, variant: string): string =>
 const stringify = (rule: Rule, directive = rule.d): string =>
   typeof directive == 'function'
     ? ''
-    : rule.v.reduce(stringifyVariant, '') + (rule.n ? '-' : '') + directive + (rule.i ? '!' : '')
+    : rule.v.reduce(stringifyVariant, '') + (rule.i ? '!' : '') + (rule.n ? '-' : '') + directive
 
 // Use hidden '_' property to collect class names which have no css translation like hashed twind classes
 const COMPONENT_PROPS = { _: { value: '', writable: true } }

--- a/src/twind/parse.ts
+++ b/src/twind/parse.ts
@@ -35,8 +35,8 @@ let rules: Rule[]
 
 // A new group has been found
 // this maybe a value (':variant' or 'prefix') or an empty marker string
-const startGrouping = (value?: string | false): '' => {
-  groupings.push(value || '')
+const startGrouping = (value = ''): '' => {
+  groupings.push(value)
   return ''
 }
 

--- a/src/types/twind.ts
+++ b/src/types/twind.ts
@@ -171,7 +171,7 @@ export interface Rule {
   /** Is this rule negated: `"-rotate-45"` =\> `true` */
   n: boolean | undefined
 
-  /** Is this rule marked as important: `"stroke-4!"` =\> `true` */
+  /** Is this rule marked as important: `"!stroke-4"` =\> `true` */
   i: boolean | undefined
 
   /**


### PR DESCRIPTION
This PR adds support for the important modifier `!` as prefix to align the syntax with windicss and tailwindcss-jit:

| Rule | Class Names |
|------|-------------|
| `!text-center` | `!text-center` |
| `!-m-8` | `!-m-8` |
| `!(text-center font-bold)` | `!text-center !font-bold` |
| `hover:!(text-center font-bold)` | `hover:!text-center hover:!font-bold` |
| `!hover:(text-center focus:font-bold)` | `hover:!text-center hover:focus:!font-bold` |
| `text!(xl underline)` | `!text-xl !text-underline` |
| `!text(xl underline) md:!m(-8)` | `!text-xl !text-underline md:!-m-8` |

The suffix syntax is still supported but the emitted class is transformed to the new syntax: `font-bold!` -> `!font-bold`

/cc @tw-in-js/contributors 
