### PR TITLE
Update link in tailwind migration guide to point to configuration page

### DIFF
--- a/docs/migration-guides/tailwind.md
+++ b/docs/migration-guides/tailwind.md
@@ -102,7 +102,7 @@ setup({
 })
 ```
 
-[Check out the docs](https://twind.dev/docs/handbook/advanced/setup.html) on the `setup` function for more configuration options like preflight, dark mode, and hashing.
+[Check out the docs](https://twind.dev/handbook/configuration.html) on the `setup` function for more configuration options like preflight, dark mode, and hashing.
 
 ### Wrap your classes in `tw` calls
 


### PR DESCRIPTION
Fixes #193

I have updated the link to the what I believe is the intended URL (https://twind.dev/handbook/configuration.html), as that contains details on the mentioned features