### PR TITLE
Docs: correct typo in variant grouping section

### DIFF
--- a/docs/handbook/grouping-syntax.md
+++ b/docs/handbook/grouping-syntax.md
@@ -131,7 +131,7 @@ tw`
   bg-red-500 shadow-xs
   sm:(
     bg-red-600
-    shadow-md
+    shadow-sm
   )
   md:(bg-red-700 shadow)
   lg:(bg-red-800 shadow-xl)


### PR DESCRIPTION
Fixes an inconsistency between the 'before variant grouping' and 'after variant grouping' examples.