### PR TITLE
fix: fix plugin detection routine

### DIFF
--- a/src/__tests__/plugins.test.ts
+++ b/src/__tests__/plugins.test.ts
@@ -138,4 +138,13 @@ test('value can be an apply directive', ({ setup, sheet }) => {
   ])
 })
 
+// See https://github.com/tw-in-js/twind/issues/189
+test('Object.prototype method names are not plugin names', ({ setup }) => {
+  const { tw } = setup()
+
+  assert.throws(() => {
+    tw('toLocaleString')
+  }, /UNKNOWN_DIRECTIVE/)
+})
+
 test.run()

--- a/src/twind/translate.ts
+++ b/src/twind/translate.ts
@@ -40,9 +40,8 @@ export const translate = (
   for (let index = parameters.length; index; index--) {
     const id = join(parameters.slice(0, index))
 
-    const plugin = plugins[id]
-
-    if (plugin) {
+    if (Object.prototype.hasOwnProperty.call(plugins, id)) {
+      const plugin = plugins[id]
       return typeof plugin == 'function'
         ? plugin(tail(parameters, index), context, id)
         : typeof plugin == 'string'


### PR DESCRIPTION
This PR fixes #189 

The availability of the plugin is checked by the expressions `const plugin = plugins[id]` & `typeof plugin === 'function'`, but this causes error when the plugin candidate id is the name of Object's method (such as `toLocaleString`). This PR fixes that detection routine by using `hasOwnProperty` method.

