### PR TITLE
docs: Updating quick-reference link

### DIFF
--- a/docs/handbook/quick-reference.md
+++ b/docs/handbook/quick-reference.md
@@ -194,7 +194,7 @@ tw`
 
 ### Configuration
 
-[View in Docs](./configuration.md#theme)
+[View in Docs](./configuration.md)
 
 The `setup` function can optionally be used to configure and extend your theme.
 


### PR DESCRIPTION
Minor copy/paste error, more than likely.

Edit: On a semi-related note, hitting the hashes next to any page title results in the URL fragment being `frontmatter-title` (e.g., `https://twind.dev/handbook/configuration.html#frontmatter-title`), which doesn't seem intentional.