### PR TITLE
feat: Export group expansion utility

### DIFF
--- a/src/colors/index.ts
+++ b/src/colors/index.ts
@@ -128,7 +128,6 @@ export const cyan = {
   900: '#164e63',
 } as const
 
-
 export const sky = {
   50: '#f0f9ff',
   100: '#e0f2fe',

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@
 export * from './twind/apply'
 export * from './twind/default'
 export * from './twind/directive'
+export * from './twind/expand'
 export * from './twind/instance'
 export * from './twind/modes'
 export * from './twind/prefix'

--- a/src/twind/expand.ts
+++ b/src/twind/expand.ts
@@ -1,0 +1,7 @@
+import { parse } from './parse'
+import { stringifyRule } from './helpers'
+
+export const expandGroups = (classNames: string): string =>
+  parse(classNames)
+    .map((rule) => stringifyRule(rule))
+    .join(' ')

--- a/src/twind/helpers.ts
+++ b/src/twind/helpers.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
-import type { CSSRules } from '../types'
+import type { CSSRules, Rule } from '../types'
 
-import { joinTruthy } from '../internal/util'
+import { joinTruthy, tail } from '../internal/util'
 
 const positions = (resolve: (position: string) => undefined | string[] | void) => (
   value: string | string[] | undefined,
@@ -60,4 +60,14 @@ export const expandEdges = (key: string): string[] | undefined => {
 // Every char must be a edge position
 // Sort to have consistent declaration ordering
 export const edges = /*#__PURE__*/ positions(expandEdges)
+
+const stringifyVariant = (selector: string, variant: string): string =>
+  selector + (variant[1] == ':' ? tail(variant, 2) + ':' : tail(variant)) + ':'
+
+// Creates rule id including variants, negate and directive
+// which is exactly like a tailwind rule
+export const stringifyRule = (rule: Rule, directive = rule.d): string =>
+  typeof directive == 'function'
+    ? ''
+    : rule.v.reduce(stringifyVariant, '') + (rule.i ? '!' : '') + (rule.n ? '-' : '') + directive
 /* eslint-enable @typescript-eslint/consistent-type-assertions */

--- a/src/twind/parse.ts
+++ b/src/twind/parse.ts
@@ -281,7 +281,7 @@ const buildStatics = (strings: TemplateStringsArray): Static[] => {
   return statics
 }
 
-export const parse = (tokens: unknown[]): Rule[] => {
+export const parse = (tokens: string | unknown[]): Rule[] => {
   groupings = []
   rules = []
 


### PR DESCRIPTION
Closes #195

Allows users to transform Twind's grouped syntax into the expanded form. This can be useful when paired with prerendering, as it allows you to remove the runtime requirement of Twind altogether (depending on your styles of course).

While writing this I thought of the name `expandGroups`, though not sure if that's better or worse than the suggested `ungroup`. Thought I'd bring it up here, but happy to edit to whatever your preference is.
