### PR TITLE
TypeScript typings improvement: replace `unknown[]` used in `apply()`, `process()`, `tw()`, and `parse()`

### DIFF
--- a/src/twind/apply.ts
+++ b/src/twind/apply.ts
@@ -1,15 +1,16 @@
-import type { Token, Directive, CSSRules, Context } from '../types'
+import type { Token, Directive, CSSRules, Context, MaybeTokenInterpolation } from '../types'
 
 import { parse } from './parse'
 import { directive } from './directive'
 
+// see MaybeTokenInterpolation type union of possible args array spread
 export interface Apply {
   (strings: TemplateStringsArray, ...interpolations: Token[]): Directive<CSSRules>
 
   (...tokens: Token[]): Directive<CSSRules>
 }
 
-const applyFactory = (tokens: unknown[], { css }: Context) => css(parse(tokens))
+const applyFactory = (tokens: MaybeTokenInterpolation, { css }: Context) => css(parse(tokens))
 
-export const apply: Apply = (...tokens: unknown[]): Directive<CSSRules> =>
+export const apply: Apply = (...tokens: MaybeTokenInterpolation): Directive<CSSRules> =>
   directive(applyFactory, tokens)

--- a/src/twind/configure.ts
+++ b/src/twind/configure.ts
@@ -11,6 +11,7 @@ import type {
   Mode,
   Falsy,
   TypescriptCompat,
+  MaybeTokenInterpolation,
 } from '../types'
 
 import { corePlugins } from './plugins'
@@ -50,7 +51,7 @@ export const configure = (
   config: Configuration = {},
 ): {
   init: () => void
-  process: (tokens: unknown[]) => string
+  process: (tokens: MaybeTokenInterpolation) => string
 } => {
   const theme = makeThemeResolver(config.theme)
 
@@ -74,7 +75,7 @@ export const configure = (
   // The context that is passed to functions to access the theme, ...
   const context: Context = {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    tw: (...tokens: unknown[]) => process(tokens),
+    tw: (...tokens: MaybeTokenInterpolation) => process(tokens),
 
     theme: ((section: keyof Theme, key?: string | string[], defaultValue?: unknown): unknown => {
       const value =
@@ -273,7 +274,7 @@ export const configure = (
 
   // This function is called from `tw(...)`
   // it parses, translates, decorates, serializes and injects the tokens
-  const process = (tokens: unknown[]): string =>
+  const process = (tokens: MaybeTokenInterpolation): string =>
     join(parse(tokens).map(convert).filter(Boolean) as string[], ' ')
 
   // Determine if we should inject the preflight (browser normalize)

--- a/src/twind/instance.ts
+++ b/src/twind/instance.ts
@@ -1,4 +1,4 @@
-import type { Configuration, Context, Instance } from '../types'
+import type { Configuration, Context, Instance, MaybeTokenInterpolation, TW } from '../types'
 
 import { configure } from './configure'
 
@@ -14,7 +14,7 @@ export const create = (config?: Configuration): Instance => {
   // This allows the error stacktrace to start at the call site.
 
   // Used by `tw`
-  let process = (tokens: unknown[]): string => {
+  let process = (tokens: MaybeTokenInterpolation): string => {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     init()
     return process(tokens)
@@ -50,7 +50,7 @@ export const create = (config?: Configuration): Instance => {
   // This ensures that after setup we use the configured
   // `process` and `setup` fails.
   return {
-    tw: Object.defineProperties((...tokens: unknown[]) => process(tokens), {
+    tw: Object.defineProperties(((...tokens: MaybeTokenInterpolation) => process(tokens)) as TW, {
       theme: {
         get: fromContext('theme'),
       },

--- a/src/types/twind.ts
+++ b/src/types/twind.ts
@@ -4,6 +4,9 @@ import type { CSSProperties, FontFace } from './css'
 import type { Theme, ThemeResolver, ThemeSectionType } from './theme'
 import type { Falsy, MaybeArray } from './util'
 
+export type MaybeObjInterpolationGeneric<T> = T[] | [TemplateStringsArray, ...T[]]
+export type MaybeTokenInterpolation = MaybeObjInterpolationGeneric<Token>
+
 export interface TWCallable {
   (strings: TemplateStringsArray, ...interpolations: Token[]): string
   (...tokens: Token[]): string
@@ -203,7 +206,7 @@ export interface TokenGrouping extends Record<string, Token> {
 
 export type TypescriptCompat = boolean | number
 
-export type Token = string | TokenGrouping | InlineDirective | Token[] | Falsy | TypescriptCompat
+export type Token = Token[] | TokenGrouping | InlineDirective | string | Falsy | TypescriptCompat
 
 /**
  * Pseudo class


### PR DESCRIPTION
This Pull Request does not change runtime logic, it just replaces `unknown[]` specifically when used for `apply()`, `process()`, `tw()`, and `parse()` (which now supports a `string` function argument recently introduced in PR #233 to expose "expand" APi)

Note that I also initially attempted to improve typings in the CSS Factory, but the ramifications were so deep and intricate that I found myself lost in `any`/`unknown` hell :) ... so I aborted and decided to propose this narrow-scope PR instead.

This PR passes `yarn build` and `yarn lint`, but note that in the `main` branch `yarn test` and `yarn test:coverage` fail with the following error (unrelated to this PR):

`twind/colors  "new colors are available"`

```
    Expected values to be deeply equal:  (equal)

        ··[
        Actual:
        --··".text-sky-200{--tw-text-opacity:1;color:#bae6fd;color:rgba(186,230,253,var(--tw-text-opacity))}",
        ····".text-rose-200{--tw-text-opacity:1;color:#fecdd3;color:rgba(254,205,211,var(--tw-text-opacity))}",
        ··]   
```
