### PR TITLE
fix: sveltekit example __layout

### DIFF
--- a/examples/with-sveltekit/src/routes/__layout.svelte
+++ b/examples/with-sveltekit/src/routes/__layout.svelte
@@ -1,4 +1,4 @@
-<script type="module">
+<script context="module">
   import { setup } from '@twind/sveltekit'
   import config from '../twind.config'
 


### PR DESCRIPTION
small fix for sveltekit example; see: https://svelte.dev/docs#component-format-script-context-module