### PR TITLE
docs: Correct named shortcut formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ We have created a few [examples](https://github.com/tw-in-js/twind/tree/next/exa
         - `hover:~(!text-(3xl,center),!underline,italic,focus:not-italic)`
         - `cx()` converts these to comma-separated group
     - named shortcuts: `PrimaryButton~(bg-red-500 text-white)` -> `PrimaryButton#<hash>`
-      - `shortcut()` is an helper to simplify creation of shortcuts (works like `apply()` in twind v0.16); it supports creating named shortcuts: `shortcut.PrimaryButton\`bg-red-500 text-white\``->`PrimaryButton#<hash>`
+      - `shortcut()` is a helper to simplify creation of shortcuts (works like `apply()` in twind v0.16); it supports creating named shortcuts: ``shortcut.PrimaryButton`bg-red-500 text-white`​`` -> `PrimaryButton#<hash>`
 - config
 
   - presets are executed in order they are defined


### PR DESCRIPTION
Was browsing the docs and saw the formatting was off. Can't escape backticks in GitHub markdown; it instead wants you to group multiple backticks to create pairs.

Note: there is in fact a zero width space in that backtick triplet, which is why this works and pairs where it does.

Corrects a minor typo as well.