### PR TITLE
fix: pass through native methods in "nested" proxy

### DIFF
--- a/.changeset/honest-spoons-cross.md
+++ b/.changeset/honest-spoons-cross.md
@@ -1,0 +1,5 @@
+---
+'twind': patch
+---
+
+fix: native methods such as `bind` not working properly when used on twind's apply helper

--- a/packages/twind/src/nested.ts
+++ b/packages/twind/src/nested.ts
@@ -13,6 +13,8 @@ function nested(marker: string): Nested {
     } as Nested,
     {
       get(target, name) {
+        if (name in nested$) return Reflect.get(nested$, name);
+        
         return function namedNested(
           strings: TemplateStringsArray | Class,
           ...interpolations: Class[]


### PR DESCRIPTION
Native function methods like `apply`, `call` or `bind` should not result in creating named classes of these functions nor brick their functionality.

This of course prevents the user from using any of these native method names for naming their components but I don't think having the ability to name a component class `apply` should take priority over being able to use native JS methods.

Resolves https://github.com/tw-in-js/twind/issues/268