### PR TITLE
Respect color type hint when parsing arbitrary color values

### DIFF
--- a/.changeset/cuddly-rules-listen.md
+++ b/.changeset/cuddly-rules-listen.md
@@ -1,0 +1,5 @@
+---
+'twind': patch
+---
+
+Respect color type hints for ambiguous arbitrary values

--- a/packages/twind/src/rules.ts
+++ b/packages/twind/src/rules.ts
@@ -220,6 +220,9 @@ export function arbitrary<Theme extends BaseTheme = BaseTheme>(
 
     // If this is a color section and the value is a hex color, color function or color name
     if (/color|fill|stroke/i.test(section)) {
+      // Respect color type hint from the user on ambiguous arbitrary values - https://tailwindcss.com/docs/adding-custom-styles#resolving-ambiguities
+      if (value.startsWith('color:')) return value.replace(/^color:/, '')
+
       if (/^(#|((hsl|rgb)a?|hwb|lab|lch|color)\(|[a-z]+$)/.test(value)) {
         return value
       }


### PR DESCRIPTION
In line with tailwindcss hint syntax: https://tailwindcss.com/docs/adding-custom-styles#resolving-ambiguities

Given a color/fill/stroke section check if user provided a value type hint and if so respect it and remove it from further parsing.

Currently does not support the other commonly used `length` type hint from tailwind (but this one should with the current code always win over untyped or ambiguous values anyway so I think we can omit it.

> Given `text-[var(--brand)]` (interpreted as ambiguous) still resolves to `font-size: var(--brand)`. Using the color type hint `text-[color:var(--brand)]` now however returns `color: var(--brand)` in line with tailwind's syntax.

Resolves #299 