### PR TITLE
feat: replace HTML entity &amp; in class names (fix #308)

### DIFF
--- a/.changeset/fair-mugs-share.md
+++ b/.changeset/fair-mugs-share.md
@@ -1,0 +1,5 @@
+---
+'twind': patch
+---
+
+Rewrites HTML entity &amp; when self-referenced groups are used with (p)react

--- a/packages/twind/src/consume.ts
+++ b/packages/twind/src/consume.ts
@@ -64,20 +64,25 @@ export function consume(markup: string, tw: (className: string) => string = tw$)
   extract(markup, (startIndex, endIndex, quote) => {
     const value = markup.slice(startIndex, endIndex)
 
-    // Lets handle some special react case that messes with arbitrary values for `content-`
-    // <span class="before:content-[&#x27;asas&#x27;]"></span>
-    // <span class="before:content-[&quot;asas&quot;]"></span>
+    // Lets handle some special react cases:
+    //   * arbitrary values for `content-`
+    //     <span class="before:content-[&#x27;asas&#x27;]"></span>
+    //     <span class="before:content-[&quot;asas&quot;]"></span>
     //
-    // if a class name contains `'` or `"` those will be replaced with HTMl entities
-    // To fix this we replace those for depending on the actual quote that is being used
-    // as an alternative we could always escape class names direcly in twind like react does
-    // but this works for now
-    const token =
+    //   * self-referenced groups
+    //     <span class="flex(&amp; col)"></span>
+    //
+    //     If a class name contains `'`, `"`, or `&` those will be replaced with HTML entities
+    //     To fix this we replace those for depending on the actual symbol that is being used
+    //     As an alternative we could always escape class names direcly in twind like react does
+    //     but this works for now
+    const token = (
       quote == `"`
         ? value.replace(/(\[)&#x27;|&#x27;(])/g, `$1'$2`)
         : quote == `'`
         ? value.replace(/(\[)&quot;|&quot;(])/g, `$1"$2`)
         : value
+    ).replace(/&amp;/g, '&')
 
     const className = tw(token)
 

--- a/packages/twind/src/tests/consume.test.ts
+++ b/packages/twind/src/tests/consume.test.ts
@@ -131,7 +131,7 @@ test('handles escaped chars by react', () => {
 
   const html = consume(
     `
-    <main class="before:content-[&#x27;x&#x27;]">
+    <main class="flex(&amp; col) before:content-[&#x27;x&#x27;]">
       <h1 class='before:content-[&quot;y&quot;]'>
         This is Twind!
       </h1>
@@ -143,7 +143,7 @@ test('handles escaped chars by react', () => {
   assert.strictEqual(
     html,
     `
-    <main class="before:content-['x']">
+    <main class="flex flex-col before:content-['x']">
       <h1 class='before:content-["y"]'>
         This is Twind!
       </h1>
@@ -151,6 +151,8 @@ test('handles escaped chars by react', () => {
     `,
   )
   assert.deepEqual(tw.target, [
+    '.flex{display:flex}',
+    '.flex-col{flex-direction:column}',
     ".before\\:content-\\[\\'x\\'\\]:before{--tw-content:'x';content:var(--tw-content)}",
     '.before\\:content-\\[\\"y\\"\\]:before{--tw-content:"y";content:var(--tw-content)}',
   ])


### PR DESCRIPTION
Closes #308

[To link to the demo again](https://esm.codes/#Ly8gRmVhdHVyZSByZXF1ZXN0IGZvciBUd2luZCBoYW5kbGluZyAmCgppbXBvcnQgeyBoLCBodG1sLCByZW5kZXIgfSBmcm9tICdodHRwczovL2Nkbi5za3lwYWNrLmRldi9odG0vcHJlYWN0JzsKaW1wb3J0IHJlbmRlclRvU3RyaW5nIGZyb20gJ2h0dHBzOi8vY2RuLnNreXBhY2suZGV2L3ByZWFjdC1yZW5kZXItdG8tc3RyaW5nJzsKaW1wb3J0IHsgZXhwYW5kR3JvdXBzIH0gZnJvbSAnaHR0cHM6Ly9jZG4uc2t5cGFjay5kZXYvdHdpbmQnOwoKaW1wb3J0IHsgZXh0cmFjdCwgc2V0dXAgfSBmcm9tICdodHRwczovL2Nkbi5za3lwYWNrLmRldi90d2luZEBuZXh0JzsKCnNldHVwKCk7Cgpjb25zdCByZW5kZXJlZFN0cmluZyA9IHJlbmRlclRvU3RyaW5nKGgoJ2RpdicsIHsgY2xhc3M6ICdmbGV4KCYgY29sKScgfSkpOwpjb25zdCByZW5kZXJlZFByb2Nlc3NlZFN0cmluZyA9IHJlbmRlclRvU3RyaW5nKGgoJ2RpdicsIHsgY2xhc3M6IGV4cGFuZEdyb3VwcygnZmxleCgmIGNvbCknKSB9KSk7Cgpjb25zb2xlLmxvZyhgUmVuZGVyZWQgU3RyaW5nOiAnJHtyZW5kZXJlZFN0cmluZ30nYCk7CmNvbnNvbGUubG9nKGBSZW5kZXJlZCBQcm9jZXNzZWQgU3RyaW5nOiAnJHtyZW5kZXJlZFByb2Nlc3NlZFN0cmluZ30nYCk7CmNvbnNvbGUubG9nKGBFeHRyYWN0IFJlbmRlcmVkIFN0cmluZzogJyR7ZXh0cmFjdChyZW5kZXJlZFN0cmluZykuaHRtbH0nYCk7CmNvbnNvbGUubG9nKGBFeHRyYWN0IFJlbmRlcmVkIFByb2Nlc3NlZCBTdHJpbmc6ICcke2V4dHJhY3QocmVuZGVyZWRQcm9jZXNzZWRTdHJpbmcpLmh0bWx9J2ApOwoKY29uc3QgQXBwID0gKCkgPT4gewogIGNvbnN0IHJlc3VsdCA9IChyKSA9PiBodG1sYDxzcGFuIHN0eWxlPSJjb2xvcjogbGltZSI+JHtyfTwvPmA7IAogIHJldHVybiBodG1sYAogICAgPGRpdiBzdHlsZT0iY29sb3I6IHdoaXRlIj4KICAgICAgPHA+UmVuZGVyZWQgU3RyaW5nOiAke3Jlc3VsdChyZW5kZXJlZFN0cmluZyl9PC8+CiAgICAgIDxwPkV4dHJhY3QgUmVuZGVyZWQgU3RyaW5nOiAke3Jlc3VsdChleHRyYWN0KHJlbmRlcmVkU3RyaW5nKS5odG1sKX08Lz4KICAgICAgPGJyIC8+CiAgICAgIDxwPlJlbmRlcmVkIFByb2Nlc3NlZCBTdHJpbmc6ICR7cmVzdWx0KHJlbmRlcmVkUHJvY2Vzc2VkU3RyaW5nKX08Lz4KICAgICAgPHA+RXh0cmFjdCBSZW5kZXJlZCBQcm9jZXNzZWQgU3RyaW5nOiAke3Jlc3VsdChleHRyYWN0KHJlbmRlcmVkUHJvY2Vzc2VkU3RyaW5nKS5odG1sKX08Lz4KICAgIDwvPgogIGA7Cn0KCnJlbmRlcihodG1sYDwke0FwcH0gLz5gLCBkb2N1bWVudC5ib2R5KTs=), (P)react will escape `&`'s in classes when rendering to a string, so I believe Twind should handle this situation and swap `&amp;` back with `&`. `.replace()` should be pretty cheap, though I do appreciate that handling HTML entities with (P)react's rather unique handling of them is a bit of a slippery slope in what is reasonable to support and what isn't.

I tried to keep the documentation comment in largely the same format while also covering `&` -- let me know if you'd like this altered in any way.