### PR TITLE
refactor: use stylis as prefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   "dependencies": {
     "@swc/helpers": "^0.3.3"
   },
-  "// style-vendorizer is included here to allow examples to find it": "",
+  "// stylis is included here to allow examples to find it": "",
   "devDependencies": {
     "@changesets/cli": "^2.20.0",
     "@changesets/get-github-info": "^0.5.0",
@@ -119,7 +119,7 @@
     "local-pkg": "^0.4.1",
     "prettier": "^2.5.1",
     "size-limit": "^7.0.8",
-    "style-vendorizer": "^2.1.1",
+    "stylis": "^4.1.0",
     "tslib": "^2.3.1",
     "typescript": "^4.5.5",
     "vitest": "^0.3.4"

--- a/packages/preset-autoprefix/package.json
+++ b/packages/preset-autoprefix/package.json
@@ -38,7 +38,7 @@
     }
   ],
   "dependencies": {
-    "stylis": "^4.1.0"
+    "stylis": "^4.1.1"
   },
   "peerDependencies": {
     "twind": "1.0.0-next.37",

--- a/packages/preset-autoprefix/package.json
+++ b/packages/preset-autoprefix/package.json
@@ -38,7 +38,7 @@
     }
   ],
   "dependencies": {
-    "style-vendorizer": "^2.1.1"
+    "stylis": "^4.1.0"
   },
   "peerDependencies": {
     "twind": "1.0.0-next.37",
@@ -50,6 +50,7 @@
     }
   },
   "devDependencies": {
+    "@types/stylis": "^4.0.2",
     "twind": "1.0.0-next.37"
   },
   "scripts": {

--- a/packages/preset-autoprefix/package.json
+++ b/packages/preset-autoprefix/package.json
@@ -50,6 +50,7 @@
     }
   },
   "devDependencies": {
+    "@twind/preset-tailwind": "1.0.0-next.37",
     "@types/stylis": "^4.0.2",
     "twind": "1.0.0-next.37"
   },

--- a/packages/preset-autoprefix/src/index.test.ts
+++ b/packages/preset-autoprefix/src/index.test.ts
@@ -1,0 +1,42 @@
+import { assert, test, afterEach } from 'vitest'
+import { twind, virtual } from 'twind'
+
+import presetTailwind from '@twind/preset-tailwind'
+import presetAutoprefix from '.'
+
+const tw = twind(
+  {
+    presets: [presetAutoprefix(), presetTailwind({ disablePreflight: true })],
+    variants: [['not-logged-in', 'body:not(.logged-in) &']],
+  },
+  virtual(),
+)
+
+afterEach(() => tw.clear())
+
+test('add prefix', () => {
+  assert.deepEqual(
+    tw('snap-x appearance-menulist-button sticky'),
+    'snap-x appearance-menulist-button sticky',
+  )
+  assert.deepEqual(tw.target, [
+    '*,::before,::after{--tw-scroll-snap-strictness:proximity}',
+    '.appearance-menulist-button{-webkit-appearance:menulist-button;-moz-appearance:menulist-button;-ms-appearance:menulist-button;appearance:menulist-button}',
+    '.sticky{position:-webkit-sticky;position:sticky}',
+    '.snap-x{-webkit-scroll-snap-type:x var(--tw-scroll-snap-strictness);-ms-scroll-snap-type:x var(--tw-scroll-snap-strictness);scroll-snap-type:x var(--tw-scroll-snap-strictness)}',
+  ])
+})
+
+test('add prefix with important', () => {
+  assert.deepEqual(
+    tw('!snap-x !appearance-menulist-button !sticky'),
+    '!snap-x !appearance-menulist-button !sticky',
+  )
+
+  assert.deepEqual(tw.target, [
+    '*,::before,::after{--tw-scroll-snap-strictness:proximity}',
+    '.\\!appearance-menulist-button{-webkit-appearance:menulist-button !important;-moz-appearance:menulist-button !important;-ms-appearance:menulist-button !important;appearance:menulist-button !important}',
+    '.\\!sticky{position:-webkit-sticky !important;position:sticky !important}',
+    '.\\!snap-x{-webkit-scroll-snap-type:x var(--tw-scroll-snap-strictness) !important;-ms-scroll-snap-type:x var(--tw-scroll-snap-strictness) !important;scroll-snap-type:x var(--tw-scroll-snap-strictness) !important}',
+  ])
+})

--- a/packages/preset-autoprefix/src/index.ts
+++ b/packages/preset-autoprefix/src/index.ts
@@ -7,40 +7,17 @@
 
 import type { Preset } from 'twind'
 
-import { cssPropertyAlias, cssPropertyPrefixFlags, cssValuePrefixFlags } from 'style-vendorizer'
-
-const CSSPrefixFlags = [
-  ['-webkit-', 1 << 0], // 0b001
-  ['-moz-', 1 << 1], // 0b010
-  ['-ms-', 1 << 2], // 0b100
-] as const
+import { prefix } from 'stylis'
 
 export default function presetAutoprefix(): Preset {
   return ({ stringify }) => ({
     stringify(property, value, context) {
-      let cssText = ''
+      /* stylis requires the unprefixed declaration to be ended with ";" */
+      const originalCssText = stringify(property, value, context) + ';'
+      const prefixedCssText = prefix(originalCssText, property.length)
 
-      // Resolve aliases, e.g. `gap` -> `grid-gap`
-      const propertyAlias = cssPropertyAlias(property)
-      if (propertyAlias) cssText += stringify(propertyAlias, value, context) + ';'
-
-      // Prefix properties, e.g. `backdrop-filter` -> `-webkit-backdrop-filter`
-      const propertyFlags = cssPropertyPrefixFlags(property)
-      const valueFlags = cssValuePrefixFlags(property, value)
-
-      for (const prefix of CSSPrefixFlags) {
-        if (propertyFlags & prefix[1]) {
-          cssText += stringify(prefix[0] + property, value, context) + ';'
-        }
-
-        if (valueFlags & prefix[1]) {
-          cssText += stringify(property, prefix[0] + value, context) + ';'
-        }
-      }
-
-      /* Include the standardized declaration last */
-      /* https://css-tricks.com/ordering-css3-properties/ */
-      return cssText + stringify(property, value, context)
+      /* stylis will make sure the standardized declaration is placed at last */
+      return prefixedCssText.endsWith(';') ? prefixedCssText.slice(0, -1) : prefixedCssText
     },
   })
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
       local-pkg: ^0.4.1
       prettier: ^2.5.1
       size-limit: ^7.0.8
-      style-vendorizer: ^2.1.1
+      stylis: ^4.1.0
       tslib: ^2.3.1
       typescript: ^4.5.5
       vitest: ^0.3.4
@@ -54,7 +54,7 @@ importers:
       local-pkg: 0.4.1
       prettier: 2.5.1
       size-limit: 7.0.8
-      style-vendorizer: 2.1.1
+      stylis: 4.1.0
       tslib: 2.3.1
       typescript: 4.5.5
       vitest: 0.3.4_4838e9f3c7bd6df8819d00262db69304
@@ -247,11 +247,13 @@ importers:
 
   packages/preset-autoprefix:
     specifiers:
-      style-vendorizer: ^2.1.1
+      '@types/stylis': ^4.0.2
+      stylis: ^4.1.0
       twind: 1.0.0-next.37
     dependencies:
-      style-vendorizer: 2.1.1
+      stylis: 4.1.0
     devDependencies:
+      '@types/stylis': 4.0.2
       twind: link:../twind
 
   packages/preset-ext:
@@ -3252,6 +3254,10 @@ packages:
     dependencies:
       '@types/node': 17.0.17
     optional: true
+
+  /@types/stylis/4.0.2:
+    resolution: {integrity: sha512-wtckGuk1eXUlUz0Qb1eXHG37Z7HWT2GfMdqRf8F/ifddTwadSS9Jwsqi4qtXk7cP7MtoyGVIHPElFCLc6HItbg==}
+    dev: true
 
   /@types/tmp/0.0.33:
     resolution: {integrity: sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=}
@@ -13042,9 +13048,6 @@ packages:
       inline-style-parser: 0.1.1
     dev: true
 
-  /style-vendorizer/2.1.1:
-    resolution: {integrity: sha512-gVO6Cwxtg8iX0X1W4xMhSc5WbQpiIBQDkhq3JkwebMRRgyhCfuvMrnPlTAGTRjfQPGRmzgjCOZ4drehTnLahHA==}
-
   /styled-jsx/5.0.0_react@17.0.2:
     resolution: {integrity: sha512-qUqsWoBquEdERe10EW8vLp3jT25s/ssG1/qX5gZ4wu15OZpmSMFI2v+fWlRhLfykA5rFtlJ1ME8A8pm/peV4WA==}
     engines: {node: '>= 12.0.0'}
@@ -13073,6 +13076,9 @@ packages:
   /stylis/4.0.13:
     resolution: {integrity: sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag==}
     dev: false
+
+  /stylis/4.1.0:
+    resolution: {integrity: sha512-SrSDzNasOCBTo7C2N9geFwydg/2bmdkWXd4gJirtq82m5JBYtR2+Ialck8czmfBLIdPxCOotlgJESPa8C1RqvA==}
 
   /subscriptions-transport-ws/0.9.19_graphql@15.8.0:
     resolution: {integrity: sha512-dxdemxFFB0ppCLg10FTtRqH/31FNRL1y1BQv8209MK5I4CwALb7iihQg+7p65lFcIl8MHatINWBLOqpgU4Kyyw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,12 +247,14 @@ importers:
 
   packages/preset-autoprefix:
     specifiers:
+      '@twind/preset-tailwind': 1.0.0-next.37
       '@types/stylis': ^4.0.2
       stylis: ^4.1.0
       twind: 1.0.0-next.37
     dependencies:
       stylis: 4.1.0
     devDependencies:
+      '@twind/preset-tailwind': link:../preset-tailwind
       '@types/stylis': 4.0.2
       twind: link:../twind
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,10 +249,10 @@ importers:
     specifiers:
       '@twind/preset-tailwind': 1.0.0-next.37
       '@types/stylis': ^4.0.2
-      stylis: ^4.1.0
+      stylis: ^4.1.1
       twind: 1.0.0-next.37
     dependencies:
-      stylis: 4.1.0
+      stylis: 4.1.1
     devDependencies:
       '@twind/preset-tailwind': link:../preset-tailwind
       '@types/stylis': 4.0.2
@@ -13081,6 +13081,11 @@ packages:
 
   /stylis/4.1.0:
     resolution: {integrity: sha512-SrSDzNasOCBTo7C2N9geFwydg/2bmdkWXd4gJirtq82m5JBYtR2+Ialck8czmfBLIdPxCOotlgJESPa8C1RqvA==}
+    dev: true
+
+  /stylis/4.1.1:
+    resolution: {integrity: sha512-lVrM/bNdhVX2OgBFNa2YJ9Lxj7kPzylieHd3TNjuGE0Re9JB7joL5VUKOVH1kdNNJTgGPpT8hmwIAPLaSyEVFQ==}
+    dev: false
 
   /subscriptions-transport-ws/0.9.19_graphql@15.8.0:
     resolution: {integrity: sha512-dxdemxFFB0ppCLg10FTtRqH/31FNRL1y1BQv8209MK5I4CwALb7iihQg+7p65lFcIl8MHatINWBLOqpgU4Kyyw==}


### PR DESCRIPTION
The PR supersedes #311 and is now targeting the `next` branch. And I also port the unit test from the `main` branch.

----

Replace `style-vendorizer` with `stylis`:

- `stylis` supports more prefixes than `style-vendorizer` (see the change of unit tests).
- `stylis` is way faster and more efficient ([here is how `stylis` implemented their prefixer](https://github.com/thysultan/stylis/blob/master/src/Prefixer.js))
- `stylis` is used by many popular CSS-in-JS libraries like [emotion](https://emotion.sh/), [linaria](https://github.com/callstack/linaria) and Vercel's [styled-jsx](https://github.com/vercel/styled-jsx)

----

The pull request is marked as a draft:

- `stylis` doesn't support prefix `tab-size` yet, https://github.com/thysultan/stylis/pull/288
- `stylis` doesn't support prefix `position:sticky !important` (however it does support `position:sticky!important`) yet, https://github.com/thysultan/stylis/pull/289