### PR TITLE
docs: Update reference of `inject` to `inline`

### DIFF
--- a/packages/twind/README.md
+++ b/packages/twind/README.md
@@ -160,7 +160,7 @@ TDB
 
 Used for static HTML processing (usually to provide SSR support for your javascript-powered web apps) — powered by [consume(html, tw)](#consumehtml-tw)
 
-**Note**: Consider using [inject](#injecthtml-tw) instead.
+**Note**: Consider using [inline](#inlinehtml-tw) instead.
 
 **Note**: This clears the Twind instance before processing the HTML.
 


### PR DESCRIPTION
Very minor, but the docs for the main twind package reference `inject` which seems to have been replaced with `inline`.

Browsing through the history, the link doesn't look to have ever been functional, so maybe just there as a TODO? Regardless I updated it, but thought I'd mention that it doesn't link up to anything at the moment.