### PR TITLE
improve remix example

### DIFF
--- a/examples/with-remix/README.md
+++ b/examples/with-remix/README.md
@@ -6,7 +6,7 @@
 
 1. a modified [app/root](./app/root.tsx)
 2. a modified [app/entry.server](./app/entry.server.tsx) to enable server-side rendering (SSR) of style
-3. (optional) a dedicated [twind.config](./twind.config.js)
+3. (optional) a dedicated [twind.config](./twind.config.ts)
 
 ## What is included?
 

--- a/examples/with-remix/remix.config.js
+++ b/examples/with-remix/remix.config.js
@@ -16,4 +16,10 @@ module.exports = {
   serverBuildDirectory: 'build',
   devServerPort: 8002,
   ignoredRouteFiles: ['.*'],
+  serverDependenciesToBundle: [
+    "@twind/with-remix",
+    "twind",
+    "@twind/preset-autoprefix",
+    "@twind/preset-tailwind",
+  ],
 }


### PR DESCRIPTION
- fixed link to twind config
- added [`serverDependenciesToBundle`](https://remix.run/docs/en/v1/api/conventions#serverdependenciestobundle) in remix config