### PR TITLE
📝 Remove duplicate of "Extension Packages" in handbook

### DIFF
--- a/docs/handbook/extended-functionality.md
+++ b/docs/handbook/extended-functionality.md
@@ -359,11 +359,3 @@ While Twind strives to maintain feature parity with Tailwind, we've added severa
 
 - Custom grouping syntax for directives and variants [View Docs](grouping-syntax)
 - Overwrite styles with the `important!` directive [View Docs](overwriting-styles)
-
-## Extension Packages
-
-- [@twind/aspect-ratio](https://github.com/tw-in-js/twind-aspect-ratio): a composable API for giving elements a fixed aspect ratio
-- [@twind/content](https://github.com/tw-in-js/twind-content): a [CSS content property](https://developer.mozilla.org/en-US/docs/Web/CSS/content) directive
-- [@twind/forms](https://github.com/tw-in-js/twind-forms): a basic reset for form styles that makes form elements easy to override with utilities
-- [@twind/line-clamp](https://github.com/tw-in-js/twind-line-clamp): utilities for visually truncating text after a fixed number of lines
-- [@twind/typography](https://github.com/tw-in-js/typography): a set of `prose` classes you can use to add beautiful typographic defaults to any vanilla HTML you don't control (like HTML rendered from Markdown, or pulled from a CMS).


### PR DESCRIPTION
Removes duplicate of "Extension Packages" in handbook.

Fixes #330 