### PR TITLE
Fix broken link in `migration.md`

### DIFF
--- a/documentation/migration.md
+++ b/documentation/migration.md
@@ -102,7 +102,7 @@ TODO with file diffs
     })
     ```
 
-    There are lots of things possible. See [preset-tailwind/rules](https://github.com/tw-in-js/twind/treee/next/packages/preset-tailwind/src/rules.ts) and [preset-ext/rules](https://github.com/tw-in-js/twind/treee/next/packages/preset-ext/src/rules.ts) for more examples.
+    There are lots of things possible. See [preset-tailwind/rules](https://github.com/tw-in-js/twind/tree/next/packages/preset-tailwind/src/rules.ts) and [preset-ext/rules](https://github.com/tw-in-js/twind/tree/next/packages/preset-ext/src/rules.ts) for more examples.
 
   - ignorelist: can be used ignore certain rules
 


### PR DESCRIPTION
The href for links after “There are lots of things possible.” had a typo in the href.