### PR TITLE
fix typo in `svelte.md`

### DIFF
--- a/docs/usage-guides/svelte.md
+++ b/docs/usage-guides/svelte.md
@@ -19,8 +19,8 @@ head:
   import { tw } from 'twind'
 </script>
 
-<main class="{tw`h-screen bg-purple-400 flex items-center justify-center`}">
-  <h1 class="{tw`font-bold text(center 5xl white sm:gray-800 md:pink-700)`}">This is Twind!</h1>
+<main class={tw`h-screen bg-purple-400 flex items-center justify-center`}>
+  <h1 class={tw`font-bold text(center 5xl white sm:gray-800 md:pink-700)`}>This is Twind!</h1>
 </main>
 ```
 


### PR DESCRIPTION
minor fix for readability, the extra `"`s aren't needed