### PR TITLE
fix: use text-decoration-line for underline

### DIFF
--- a/src/__tests__/api.json
+++ b/src/__tests__/api.json
@@ -41,9 +41,9 @@
   "not-italic": ".not-italic{font-style:normal}",
   "font-italic": ".font-italic{font-style:italic}",
   "font-not-italic": ".font-not-italic{font-style:normal}",
-  "underline": ".underline{text-decoration:underline}",
-  "no-underline": ".no-underline{text-decoration:none}",
-  "line-through": ".line-through{text-decoration:line-through}",
+  "underline": ".underline{text-decoration-line:underline}",
+  "no-underline": ".no-underline{text-decoration-line:none}",
+  "line-through": ".line-through{text-decoration-line:line-through}",
   "uppercase": ".uppercase{text-transform:uppercase}",
   "lowercase": ".lowercase{text-transform:lowercase}",
   "capitalize": ".capitalize{text-transform:capitalize}",
@@ -53,9 +53,9 @@
   "list-none": ".list-none{list-style-type:none}",
   "list-disc": ".list-disc{list-style-type:disc}",
   "list-decimal": ".list-decimal{list-style-type:decimal}",
-  "text-underline": ".text-underline{text-decoration:underline}",
-  "text-no-underline": ".text-no-underline{text-decoration:none}",
-  "text-line-through": ".text-line-through{text-decoration:line-through}",
+  "text-underline": ".text-underline{text-decoration-line:underline}",
+  "text-no-underline": ".text-no-underline{text-decoration-line:none}",
+  "text-line-through": ".text-line-through{text-decoration-line:line-through}",
   "text-uppercase": ".text-uppercase{text-transform:uppercase}",
   "text-lowercase": ".text-lowercase{text-transform:lowercase}",
   "text-capitalize": ".text-capitalize{text-transform:capitalize}",
@@ -480,16 +480,16 @@
     [
       ".text-2xl{font-size:1.5rem;line-height:2rem}",
       ".text-center{text-align:center}",
-      ".underline{text-decoration:underline}"
+      ".underline{text-decoration-line:underline}"
     ]
   ],
   "((underline) (text(center 2xl)) (((font(bold)))))": [
     "underline text-center text-2xl font-bold",
     [
       ".text-2xl{font-size:1.5rem;line-height:2rem}",
-      ".underline{text-decoration:underline}",
       ".text-center{text-align:center}",
-      ".font-bold{font-weight:700}"
+      ".font-bold{font-weight:700}",
+      ".underline{text-decoration-line:underline}"
     ]
   ],
   "text(indigo-700 opacity-70)": [
@@ -534,8 +534,8 @@
       ".my-2{margin-bottom:0.5rem;margin-top:0.5rem}",
       ".px-5{padding-left:1.25rem;padding-right:1.25rem}",
       ".text-center{text-align:center}",
-      ".underline{text-decoration:underline}",
-      ".font-bold{font-weight:700}"
+      ".font-bold{font-weight:700}",
+      ".underline{text-decoration-line:underline}"
     ]
   ],
   "group hover:bg-gray-300": [
@@ -633,7 +633,7 @@
       ".text-purple-500{--tw-text-opacity:1;color:#8b5cf6;color:rgba(139,92,246,var(--tw-text-opacity))}",
       ".text-lg{font-size:1.125rem;line-height:1.75rem}",
       ".text-capitalize{text-transform:capitalize}",
-      ".text-underline{text-decoration:underline}"
+      ".text-underline{text-decoration-line:underline}"
     ]
   ],
   "font(sans italic bold)": [
@@ -662,7 +662,7 @@
       ".hover\\:text-center:hover{text-align:center}",
       ".hover\\:active\\:ring:hover:active{--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow,0 0 transparent)}",
       ".active\\:hover\\:text-lg:active:hover{font-size:1.125rem;line-height:1.75rem}",
-      ".hover\\:active\\:text-underline:hover:active{text-decoration:underline}",
+      ".hover\\:active\\:text-underline:hover:active{text-decoration-line:underline}",
       ".hover\\:active\\:ring-opacity-5:hover:active{--tw-ring-opacity:0.05}"
     ]
   ],
@@ -671,9 +671,9 @@
     [
       ".transition{transition-property:background-color,border-color,color,fill,stroke,opacity,box-shadow,transform,filter,backdrop-filter;transition-timing-function:cubic-bezier(0.4,0,0.2,1);transition-duration:150ms}",
       ".text-4xl{font-size:2.25rem;line-height:2.5rem}",
-      ".text-underline{text-decoration:underline}",
       ".font-bold{font-weight:700}",
       ".font-sans{font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,\"Helvetica Neue\",Arial,\"Noto Sans\",sans-serif,\"Apple Color Emoji\",\"Segoe UI Emoji\",\"Segoe UI Symbol\",\"Noto Color Emoji\"}",
+      ".text-underline{text-decoration-line:underline}",
       ".hover\\:transform:hover{--tw-translate-x:0;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}",
       ".hover\\:scale-125:hover{--tw-scale-x:1.25;--tw-scale-y:1.25;transform:scale(1.25);transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}",
       ".hover\\:rotate-6:hover{--tw-rotate:6deg;transform:rotate(6deg);transform:translateX(var(--tw-translate-x,0)) translateY(var(--tw-translate-y,0)) rotate(var(--tw-rotate,0)) skewX(var(--tw-skew-x,0)) skewY(var(--tw-skew-y,0)) scaleX(var(--tw-scale-x,1)) scaleY(var(--tw-scale-y,1))}",
@@ -792,9 +792,9 @@
   "proportional-nums": ".proportional-nums{--tw-numeric-spacing:proportional-nums;font-variant-numeric:var(--tw-ordinal,/*!*/ /*!*/) var(--tw-slashed-zero,/*!*/ /*!*/) var(--tw-numeric-figure,/*!*/ /*!*/) var(--tw-numeric-spacing,/*!*/ /*!*/) var(--tw-numeric-fraction,/*!*/ /*!*/)}",
   "diagonal-fractions": ".diagonal-fractions{--tw-numeric-fraction:diagonal-fractions;font-variant-numeric:var(--tw-ordinal,/*!*/ /*!*/) var(--tw-slashed-zero,/*!*/ /*!*/) var(--tw-numeric-figure,/*!*/ /*!*/) var(--tw-numeric-spacing,/*!*/ /*!*/) var(--tw-numeric-fraction,/*!*/ /*!*/)}",
   "stacked-fractions": ".stacked-fractions{--tw-numeric-fraction:stacked-fractions;font-variant-numeric:var(--tw-ordinal,/*!*/ /*!*/) var(--tw-slashed-zero,/*!*/ /*!*/) var(--tw-numeric-figure,/*!*/ /*!*/) var(--tw-numeric-spacing,/*!*/ /*!*/) var(--tw-numeric-fraction,/*!*/ /*!*/)}",
-  "children:underline": ".children\\:underline>*{text-decoration:underline}",
-  "siblings:underline": ".siblings\\:underline~*{text-decoration:underline}",
-  "sibling:underline": ".sibling\\:underline+*{text-decoration:underline}",
+  "children:underline": ".children\\:underline>*{text-decoration-line:underline}",
+  "siblings:underline": ".siblings\\:underline~*{text-decoration-line:underline}",
+  "sibling:underline": ".sibling\\:underline+*{text-decoration-line:underline}",
   "!text-center": ".\\!text-center{text-align:center !important}",
   "text-center!": ["!text-center", [".\\!text-center{text-align:center !important}"]],
   "!(text-center font-bold)": [
@@ -826,7 +826,7 @@
     "!text-xl !text-underline",
     [
       ".\\!text-xl{font-size:1.25rem !important;line-height:1.75rem !important}",
-      ".\\!text-underline{text-decoration:underline !important}"
+      ".\\!text-underline{text-decoration-line:underline !important}"
     ]
   ],
   "!-m-8": ".\\!-m-8{margin:calc(2rem * -1) !important}",
@@ -834,7 +834,7 @@
     "!text-xl !text-underline md:!-m-8",
     [
       ".\\!text-xl{font-size:1.25rem !important;line-height:1.75rem !important}",
-      ".\\!text-underline{text-decoration:underline !important}",
+      ".\\!text-underline{text-decoration-line:underline !important}",
       "@media (min-width:768px){.md\\:\\!-m-8{margin:calc(2rem * -1) !important}}"
     ]
   ],

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -322,7 +322,7 @@ test('properties presedence (divide)', ({ sheet, tw }) => {
       '@media (min-width:1024px){.lg\\:hover\\:text-black:hover{--tw-text-opacity:1;color:#000;color:rgba(0,0,0,var(--tw-text-opacity))}}',
       '@media (min-width:1024px){.lg\\:hover\\:bg-white:hover{--tw-bg-opacity:1;background-color:#fff;background-color:rgba(255,255,255,var(--tw-bg-opacity))}}',
       '@media (min-width:1024px){.lg\\:hover\\:active\\:shadow:hover:active{--tw-shadow:0 1px 3px 0 rgba(0,0,0,0.1), 0 1px 2px 0 rgba(0,0,0,0.06);box-shadow:0 1px 3px 0 rgba(0,0,0,0.1), 0 1px 2px 0 rgba(0,0,0,0.06);box-shadow:var(--tw-ring-offset-shadow,0 0 transparent),var(--tw-ring-shadow,0 0 transparent),var(--tw-shadow)}}',
-      '@media (min-width:1024px){.lg\\:hover\\:active\\:underline:hover:active{text-decoration:underline}}',
+      '@media (min-width:1024px){.lg\\:hover\\:active\\:underline:hover:active{text-decoration-line:underline}}',
     ],
   ],
 ].forEach(([tokens, classNames, rules]) => {
@@ -394,9 +394,9 @@ test('tw`bg-white sm:${["rounded"]} text-black hover:${{sm: ({tw}) => tw`underli
     '.bg-white{--tw-bg-opacity:1;background-color:#fff;background-color:rgba(255,255,255,var(--tw-bg-opacity))}',
     '.font-bold{font-weight:700}',
     '@media (min-width:640px){.sm\\:rounded{border-radius:0.25rem}}',
-    '@media (min-width:640px){.hover\\:sm\\:underline:hover{text-decoration:underline}}',
-    '@media (min-width:1024px){.hover\\:lg\\:no-underline:hover{text-decoration:none}}',
-    '@media (min-width:1024px){.hover\\:lg\\:line-through:hover{text-decoration:line-through}}',
+    '@media (min-width:640px){.hover\\:sm\\:underline:hover{text-decoration-line:underline}}',
+    '@media (min-width:1024px){.hover\\:lg\\:no-underline:hover{text-decoration-line:none}}',
+    '@media (min-width:1024px){.hover\\:lg\\:line-through:hover{text-decoration-line:line-through}}',
   ])
 })
 
@@ -424,10 +424,10 @@ test('tw`bg-${"fuchsia"}) sm:${"underline"} lg:${false && "line-through"} text-$
   )
   assert.equal(sheet.target, [
     '.bg-fuchsia{background-color:fuchsia}',
-    '.text-underline{text-decoration:underline}',
     '.text-center{text-align:center}',
+    '.text-underline{text-decoration-line:underline}',
     '.rounded-xl{border-radius:0.75rem}',
-    '@media (min-width:640px){.sm\\:underline{text-decoration:underline}}',
+    '@media (min-width:640px){.sm\\:underline{text-decoration-line:underline}}',
   ])
 })
 
@@ -462,7 +462,7 @@ test('tw`hover:${() => ...} bg-${"red"}-600 ${"underline"}`', ({ tw, sheet }) =>
   )
   assert.equal(sheet.target, [
     '.bg-red-600{--tw-bg-opacity:1;background-color:#dc2626;background-color:rgba(220,38,38,var(--tw-bg-opacity))}',
-    '.underline{text-decoration:underline}',
+    '.underline{text-decoration-line:underline}',
     '.tw-41gqd9:hover{color:fuchsia}',
   ])
 })
@@ -654,9 +654,9 @@ test('inline rule (tw combined)', ({ sheet, tw }) => {
     'underline text-center font-bold',
   )
   assert.equal(sheet.target, [
-    '.underline{text-decoration:underline}',
     '.text-center{text-align:center}',
     '.font-bold{font-weight:700}',
+    '.underline{text-decoration-line:underline}',
   ])
 })
 
@@ -668,7 +668,7 @@ test('inline rule (variants)', ({ sheet, tw }) => {
   assert.equal(sheet.target, [
     '.text-center{text-align:center}',
     '.active\\:font-bold:active{font-weight:700}',
-    '@media (min-width:640px){.sm\\:hover\\:underline:hover{text-decoration:underline}}',
+    '@media (min-width:640px){.sm\\:hover\\:underline:hover{text-decoration-line:underline}}',
   ])
 })
 
@@ -693,9 +693,9 @@ test('inline rule nested', ({ sheet, tw }) => {
   assert.equal(sheet.target, [
     '.text-center{text-align:center}',
     '.font-bold{font-weight:700}',
-    '@media (min-width:640px){.sm\\:hover\\:underline:hover{text-decoration:underline}}',
+    '@media (min-width:640px){.sm\\:hover\\:underline:hover{text-decoration-line:underline}}',
     '@media (min-width:1024px){.lg\\:text-lg{font-size:1.125rem;line-height:1.75rem}}',
-    '@media (min-width:1024px){.lg\\:focus\\:underline:focus{text-decoration:underline}}',
+    '@media (min-width:1024px){.lg\\:focus\\:underline:focus{text-decoration-line:underline}}',
     '@media (min-width:640px){.tw-1xfd7yc:focus{color:#ef4444}}',
   ])
 })
@@ -884,7 +884,7 @@ test('@screen (object notation)', ({ tw, sheet }) => {
   assert.is(tw(style), 'tw-svjqbe')
   assert.equal(sheet.target, [
     '@media (min-width:640px){.tw-svjqbe{match:sm}}',
-    '@media (min-width:1536px){.tw-svjqbe{text-decoration:underline}}',
+    '@media (min-width:1536px){.tw-svjqbe{text-decoration-line:underline}}',
   ])
 })
 
@@ -899,7 +899,7 @@ test('@apply (object notation)', ({ tw, sheet }) => {
 
   assert.is(tw(style), 'tw-1dlm15h')
   assert.equal(sheet.target, [
-    '.tw-1dlm15h{font-weight:700;padding-bottom:0.5rem;padding-top:0.5rem;padding-left:1rem;padding-right:1rem;text-decoration:underline;color:fuchsia;transform:translateY(-1px)}',
+    '.tw-1dlm15h{font-weight:700;padding-bottom:0.5rem;padding-top:0.5rem;padding-left:1rem;padding-right:1rem;text-decoration-line:underline;color:fuchsia;transform:translateY(-1px)}',
   ])
 })
 
@@ -914,7 +914,7 @@ test('using @apply with array', ({ tw, sheet }) => {
 
   assert.is(tw(style), 'tw-v9zanm')
   assert.equal(sheet.target, [
-    '.tw-v9zanm{font-weight:700;text-decoration:underline;padding-bottom:0.5rem;padding-top:0.5rem;padding-left:1rem;padding-right:1rem;color:fuchsia;transform:translateY(-1px)}',
+    '.tw-v9zanm{font-weight:700;text-decoration-line:underline;padding-bottom:0.5rem;padding-top:0.5rem;padding-left:1rem;padding-right:1rem;color:fuchsia;transform:translateY(-1px)}',
   ])
 })
 
@@ -931,8 +931,8 @@ test('using @apply with variant', ({ tw, sheet }) => {
 
   assert.is(tw(style), 'tw-1plavv4')
   assert.equal(sheet.target, [
-    '.tw-1plavv4:hover{text-decoration:underline;transform:translateY(-1px)}',
     '.tw-1plavv4{font-weight:700;color:fuchsia}',
+    '.tw-1plavv4:hover{text-decoration-line:underline;transform:translateY(-1px)}',
   ])
 })
 

--- a/src/__tests__/apply.test.ts
+++ b/src/__tests__/apply.test.ts
@@ -101,7 +101,7 @@ test('css can be used', ({ tw, sheet }) => {
   assert.equal(sheet.target, [
     '.tw-1ky59p5{padding-bottom:0.5rem;padding-top:0.5rem;padding-left:1rem;padding-right:1rem;border-color:black}',
     '.tw-x66wbi{padding-left:2rem;padding-right:2rem}',
-    '.tw-1tbrnfj{text-decoration:underline}',
+    '.tw-1tbrnfj{text-decoration-line:underline}',
   ])
 })
 
@@ -420,10 +420,10 @@ test('applied rules can be used alone after apply', ({ tw, sheet }) => {
 })
 
 test('applied rules are within component layer', ({ tw, sheet }) => {
-  assert.is(tw(apply`underline`, 'bg-red-500'), 'tw-1h2u08d tw-1u8yv89')
+  assert.is(tw(apply`underline`, 'bg-red-500'), 'tw-1gmjw68 tw-1u8yv89')
 
   assert.equal(sheet.target, [
-    '.tw-1h2u08d{text-decoration:underline}',
+    '.tw-1gmjw68{text-decoration-line:underline}',
     '.tw-1u8yv89{--tw-17cwy6m:1;background-color:#ef4444;background-color:rgba(239,68,68,var(--tw-17cwy6m))}',
   ])
 
@@ -433,7 +433,7 @@ test('applied rules are within component layer', ({ tw, sheet }) => {
 
   assert.equal(sheet.target, [
     '.tw-1u8yv89{--tw-17cwy6m:1;background-color:#ef4444;background-color:rgba(239,68,68,var(--tw-17cwy6m))}',
-    '.tw-1tbrnfj{text-decoration:underline}',
+    '.tw-1tbrnfj{text-decoration-line:underline}',
   ])
 })
 

--- a/src/__tests__/mode.test.ts
+++ b/src/__tests__/mode.test.ts
@@ -98,8 +98,8 @@ test('ignore vendor specific pseudo classes errors', () => {
   assert.equal(calls, [
     ['::-moz-focus-inner{border-style:none}', 0],
     [':-moz-focusring{outline:1px dotted ButtonText}', 0],
-    ['.underline{-webkit-text-decoration:underline;text-decoration:underline}', 0],
-    ['.text-center{text-align:center}', 1],
+    ['.underline{text-decoration-line:underline}', 0],
+    ['.text-center{text-align:center}', 0],
   ])
 
   assert.is(warn.callCount, 0)
@@ -133,7 +133,7 @@ test('propagate other errors to warn', () => {
 
   assert.equal(calls, [
     ['.invalid-web{color:blue}', 0],
-    ['.underline{-webkit-text-decoration:underline;text-decoration:underline}', 0],
+    ['.underline{text-decoration-line:underline}', 0],
   ])
 
   assert.is(warn.callCount, 1)

--- a/src/__tests__/setup.test.ts
+++ b/src/__tests__/setup.test.ts
@@ -80,7 +80,7 @@ test('important', () => {
   )
   assert.equal(sheet.target, [
     '.tw-nziaos{font-size:1.25rem !important;line-height:1.75rem !important}',
-    '.underline{text-decoration:underline !important}',
+    '.underline{text-decoration-line:underline !important}',
     '.tw-yinfv4{color:#ef4444 !important}',
   ])
 })

--- a/src/server/async-sheet.test.ts
+++ b/src/server/async-sheet.test.ts
@@ -92,13 +92,13 @@ if (Number(process.versions.node.split('.')[0]) >= 12) {
     assert.match(first.textContent, '.text-center{text-align:center}.font-bold{font-weight:700}')
     assert.not.match(
       first.textContent,
-      '.italic{font-style:italic}.underline{-webkit-text-decoration:underline;text-decoration:underline}',
+      '.italic{font-style:italic}.underline{text-decoration-line:underline}',
     )
 
     assert.match(second.textContent, 'ol,ul{list-style:none}')
     assert.match(
       second.textContent,
-      '.italic{font-style:italic}.underline{-webkit-text-decoration:underline;text-decoration:underline}',
+      '.italic{font-style:italic}.underline{text-decoration-line:underline}',
     )
     assert.not.match(
       second.textContent,

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -43,9 +43,9 @@ test('The "tw" property is evaluated', ({ sheet, tw }) => {
 
   assert.equal(sheet.target, [])
 
-  assert.is(tw(component({ tw: `underline` })), 'tw-17aav39 tw-146i9et')
+  assert.is(tw(component({ tw: `underline` })), 'tw-tfsxaf tw-146i9et')
   assert.equal(sheet.target, [
-    '.tw-17aav39{font-size:1rem;line-height:1.5rem;text-decoration:underline}',
+    '.tw-tfsxaf{font-size:1rem;line-height:1.5rem;text-decoration-line:underline}',
   ])
 
   sheet.reset()

--- a/src/twind/plugins.ts
+++ b/src/twind/plugins.ts
@@ -72,7 +72,7 @@ const alias = (handler: PluginHandler, name: string): PluginHandler => (params, 
 const display = property('display')
 const position = property('position')
 const textTransform = property('textTransform')
-const textDecoration = property('textDecoration')
+const textDecorationLine = property('textDecorationLine')
 const fontStyle = property('fontStyle')
 const fontVariantNumeric = (key: string): PluginHandler => (params, context, id) => ({
   ['--tw-' + key]: id,
@@ -490,13 +490,13 @@ export const corePlugins: Record<string, Plugin | undefined> = {
           left: _,
         },
 
-  underline: textDecoration,
-  'line-through': textDecoration,
-  'no-underline': alias(textDecoration, 'none'),
+  underline: textDecorationLine,
+  'line-through': textDecorationLine,
+  'no-underline': alias(textDecorationLine, 'none'),
 
-  'text-underline': alias(textDecoration, 'underline'),
-  'text-no-underline': alias(textDecoration, 'none'),
-  'text-line-through': alias(textDecoration, 'line-through'),
+  'text-underline': alias(textDecorationLine, 'underline'),
+  'text-no-underline': alias(textDecorationLine, 'none'),
+  'text-line-through': alias(textDecorationLine, 'line-through'),
 
   uppercase: textTransform,
   lowercase: textTransform,


### PR DESCRIPTION
closes #377 

This PR uses `text-decoration-line` property for text decoration classes. Now `underline` class becomes `.underline{text-decoration-line:underline}`.

This improves the compatibility to tailwind. https://tailwindcss.com/docs/text-decoration