### PR TITLE
fix: "warn" message doesn't respect `event.preventDefault()` (fix #403)

### DIFF
--- a/.changeset/nervous-pandas-itch.md
+++ b/.changeset/nervous-pandas-itch.md
@@ -1,0 +1,5 @@
+---
+'@twind/core': patch
+---
+
+Fixes "warn" message doesn't respect `event.preventDefault()` (#403)

--- a/packages/core/src/internal/warn.ts
+++ b/packages/core/src/internal/warn.ts
@@ -23,7 +23,10 @@ export function warn<Code extends keyof WarningEventMap>(
   if (DEV) {
     if (typeof dispatchEvent == 'function' && typeof CustomEvent === 'function') {
       // Browser
-      const event = new CustomEvent('warning', { detail: { message, code, detail } })
+      const event = new CustomEvent('warning', {
+        detail: { message, code, detail },
+        cancelable: true,
+      })
 
       dispatchEvent(event)
 


### PR DESCRIPTION
You might find our contributing section about [Submitting Pull Requests](https://github.com/tw-in-js/twind/blob/main/CONTRIBUTING.md#submitting-pull-requests) helpful.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] ~~Ideally, include a test that fails without this PR but passes with it.~~

---

### What
Add `cancelable: true` in warn.ts so the `event.defaultPrevented` can actually becomes `true` (see: #403).

### Tests

- [x] Run the tests with `pnpm test` and verify the project with `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until Twind 1.0
