### PR TITLE
allow typescript v5

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
     "csstype": "^3.1.1"
   },
   "peerDependencies": {
-    "typescript": "^4.8.4"
+    "typescript": "^4.8.4 || ^5"
   },
   "peerDependenciesMeta": {
     "typescript": {


### PR DESCRIPTION
You might find our contributing section about [Submitting Pull Requests](https://github.com/tw-in-js/twind/blob/main/CONTRIBUTING.md#submitting-pull-requests) helpful.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] ~Ideally, include a test that fails without this PR but passes with it.~

### Tests

- [ ] Run the tests with `pnpm test` and verify the project with `pnpm check`

### Changesets

- [ ] ~If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until Twind 1.0~

just allows typescript v5 to be used. closes #497 